### PR TITLE
Three more fixes

### DIFF
--- a/pyworkflow/em/packages/eman2/protocol_refineasy.py
+++ b/pyworkflow/em/packages/eman2/protocol_refineasy.py
@@ -303,13 +303,15 @@ at each refinement step. The resolution you specify is a target, not the filter 
         errors = []
         validateVersion(self, errors)
 
-        samplingRate = self._getInputParticles().getSamplingRate()
-        if self.resol.get() < 2*samplingRate:
+        particles = self._getInputParticles()
+        samplingRate = particles.getSamplingRate()
+
+        if self.resol <  2 * samplingRate:
             errors.append("\nTarget resolution is smaller than 2*samplingRate value. This is impossible.")
         
         if not self.doContinue:
-            self._validateDim(self._getInputParticles(), self.referenceVolume.get(),
-                          'Input particles', 'Reference volume')
+            self._validateDim(particles, self.input3DReference.get(), errors,
+                              'Input particles', 'Reference volume')
 
         return errors
     

--- a/pyworkflow/em/packages/grigoriefflab/protocol_frealign_base.py
+++ b/pyworkflow/em/packages/grigoriefflab/protocol_frealign_base.py
@@ -723,7 +723,7 @@ class ProtFrealignBase(EMProtocol):
             errors.append('Missing ' + FREALIGN_PATH)
 
         if not self.doContinue:
-            self._validateDim(imgSet, self.input3DReference.get(),
+            self._validateDim(imgSet, self.input3DReference.get(), errors,
                               'Input particles', 'Reference volume')
 
         halfX = partSizeX % 2

--- a/pyworkflow/em/packages/relion/protocol_classify3d.py
+++ b/pyworkflow/em/packages/relion/protocol_classify3d.py
@@ -102,7 +102,7 @@ class ProtRelionClassify3D(ProtClassify3D, ProtRelionBase):
         """
         errors = []
         self._validateDim(self._getInputParticles(), self.referenceVolume.get(),
-                          'Input particles', 'Reference volume')
+                          errors, 'Input particles', 'Reference volume')
         return errors
     
     def _validateContinue(self):

--- a/pyworkflow/em/packages/relion/protocol_refine3d.py
+++ b/pyworkflow/em/packages/relion/protocol_refine3d.py
@@ -118,7 +118,7 @@ leads to objective and high-quality results.
         """
         errors = []
         self._validateDim(self._getInputParticles(), self.referenceVolume.get(),
-                          'Input particles', 'Reference volume')
+                          errors, 'Input particles', 'Reference volume')
         return errors
     
     def _validateContinue(self):

--- a/pyworkflow/em/packages/xmipp3/protocol_projmatch/protocol_projmatch.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_projmatch/protocol_projmatch.py
@@ -220,7 +220,7 @@ class XmippProtProjMatch(ProtRefine3D, ProtClassify3D):
             errors.append("The number of MPI processes has to be larger than 1")
         
         self._validateDim(self.inputParticles.get(), self.input3DReferences.get(),
-                          'Input particles', 'Reference volume')
+                          errors, 'Input particles', 'Reference volume')
 
         return errors
     

--- a/pyworkflow/tests/em/protocols/test_protocols_xmipp_2d.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_xmipp_2d.py
@@ -852,7 +852,10 @@ class TestXmippBreakSym(TestXmippBase):
         protBreakSym.inputParticles.set(protImport.outputParticles)
         self.launchProtocol(protBreakSym)
         os.chdir(protBreakSym._getPath())
-        os.system("scipion xmipp_angular_distance --ang1 images.xmd --ang2 input_particles.xmd --sym i2 --oroot kk")
+        from pyworkflow.utils import runJob
+        runJob(None, 'xmipp_angular_distance',
+               "--ang1 images.xmd --ang2 input_particles.xmd --sym i2 --oroot kk",
+               env=getEnviron())
         mdRober = md.MetaData("kk_vec_diff_hist.txt")
         objId = mdRober.firstObject()
         count = mdRober.getValue(md.MDL_COUNT, objId)

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -231,11 +231,12 @@ class Tester():
                                   t.getToc(), result, logFile)
 
     def runTests(self, tests):
+        self.testCount = 0
+        
         if self.log:
             self.testsDir = join(os.environ['SCIPION_USER_DATA'], 'Tests', self.log)
             pwutils.cleanPath(self.testsDir)
             pwutils.makePath(self.testsDir)
-            self.testCount = 0
             self.testLog = join(self.testsDir, 'tests.html')
             self.testTimer = pwutils.Timer()
             self.testTimer.tic()
@@ -260,10 +261,10 @@ class Tester():
     
     </body>
     </html>""")
-            
-            f.close()        
+
+            f.close()
         self._visitTests(tests, self._runNewItem)
-        
+
         print "\n\nOpen results in your browser: \nfile:///%s" % self.testLog
         
     def runSingleTest(self, tests):

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -232,7 +232,7 @@ class Tester():
 
     def runTests(self, tests):
         self.testCount = 0
-        
+
         if self.log:
             self.testsDir = join(os.environ['SCIPION_USER_DATA'], 'Tests', self.log)
             pwutils.cleanPath(self.testsDir)
@@ -265,7 +265,8 @@ class Tester():
             f.close()
         self._visitTests(tests, self._runNewItem)
 
-        print "\n\nOpen results in your browser: \nfile:///%s" % self.testLog
+        if self.log:
+            print "\n\nOpen results in your browser: \nfile:///%s" % self.testLog
         
     def runSingleTest(self, tests):
         result = GTestResult()


### PR DESCRIPTION
Three fixes:
* added missing parameter **errors** to the *_validateDim* function
* initialized counter when running tests
* removed the use of os.system('scipion....') in break symmetry test