### PR TITLE
Ctf viewer clean-up and PSD display fixed

### DIFF
--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -260,14 +260,7 @@ class XmippViewer(Viewer):
             self._visualize(obj.outputCTF)
         
         elif issubclass(cls, SetOfCTF):
-            fn = obj.getFileName()
-#            self._views.append(DataView(fn, viewParams={MODE: 'metadata'}))
-            psdLabels = '_psdFile _xmipp_enhanced_psd _xmipp_ctfmodel_quadrant _xmipp_ctfmodel_halfplane'
-            labels = 'id enabled label %s _defocusU _defocusV _defocusAngle _defocusRatio ' \
-                     '_xmipp_ctfCritFirstZero _xmipp_ctfCritCorr13 _xmipp_ctfCritFitting _xmipp_ctfCritNonAstigmaticValidity ' \
-                     '_xmipp_ctfCritCtfMargin _xmipp_ctfCritMaxFreq _micObj._filename' % psdLabels #TODO:CHECK IF _xmipp_ctfCritNonAstigmaticValidity AND _xmipp_ctfCritCtfMargin exist sometimes. 
-            self._views.append(ObjectView(self._project, obj.strId(), fn,
-                                          viewParams={MODE: MODE_MD, ORDER: labels, VISIBLE: labels, ZOOM: 50, RENDER: psdLabels}))    
+            self._views.append(CtfView(self._project, obj))
 
         elif issubclass(cls, CoordinatesTiltPair):
             tmpDir = self._getTmpPath(obj.getName()) 

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -107,51 +107,37 @@ class XmippViewer(Viewer):
         
         for v in self._views:
             v.show()
-            
+
+    def __createTemporaryCtfs(self, obj, setOfMics):
+        pwutils.cleanPath(obj._getPath("ctfs_temporary.sqlite"))
+        self.protocol._createFilenameTemplates()
+        ctfSet = self.protocol._createSetOfCTF("_temporary")
+
+        for mic in setOfMics:
+            micDir = obj._getExtraPath(removeBaseExt(mic.getFileName()))
+            ctfparam = self.protocol._getFileName('ctfparam', micDir=micDir)
+
+            if exists(ctfparam) or exists('xmipp_default_ctf.ctfparam'):
+                if not os.path.exists(ctfparam):
+                    ctfparam = 'xmipp_default_ctf.ctfparam'
+                ctfModel = readCTFModel(ctfparam, mic)
+                self.protocol._setPsdFiles(ctfModel, micDir)
+                ctfSet.append(ctfModel)
+
+        if not ctfSet.isEmpty():
+            ctfSet.write()
+            ctfSet.close()
+
+        return ctfSet
+
     def _visualize(self, obj, **args):
         cls = type(obj)
-        def _getMicrographDir(mic):
-            """ Return an unique dir name for results of the micrograph. """
-            return obj._getExtraPath(removeBaseExt(mic.getFileName()))        
-    
-        def iterMicrographs(mics):
-            """ Iterate over micrographs and yield
-            micrograph name and a directory to process.
-            """
-            for mic in mics:
-                micFn = mic.getFileName()
-                micDir = _getMicrographDir(mic) 
-                yield (micFn, micDir, mic)
-    
-        def visualizeCTFObjs(obj, setOfMics):
-            
-            if exists(obj._getPath("ctfs_temporary.sqlite")):
-                os.remove(obj._getPath("ctfs_temporary.sqlite"))
-            self.protocol._createFilenameTemplates()
-            
-            ctfSet = self.protocol._createSetOfCTF("_temporary")
-            
-            for fn, micDir, mic in iterMicrographs(setOfMics):
-                ctfparam = self.protocol._getFileName('ctfparam', micDir=micDir)
-                
-                if exists(ctfparam) or exists('xmipp_default_ctf.ctfparam'):
-                    if not os.path.exists(ctfparam):
-                        ctfparam = 'xmipp_default_ctf.ctfparam'
-                    
-                    ctfModel = readCTFModel(ctfparam, mic)
-                    self.protocol._setPsdFiles(ctfModel, micDir)
-                    ctfSet.append(ctfModel)
-            
-            if ctfSet.getSize() < 1:
-                raise Exception("Has not been completed the CTT estimation of any micrograph")
-            else:
-                ctfSet.write()
-                ctfSet.close()
-                self._visualize(ctfSet)
 
         if issubclass(cls, Volume):
             fn = getImageLocation(obj)
-            self._views.append(ObjectView(self._project, obj.strId(), fn, viewParams={RENDER: 'image', SAMPLINGRATE: obj.getSamplingRate()}))
+            self._views.append(ObjectView(self._project, obj.strId(), fn,
+                                          viewParams={RENDER: 'image',
+                                                      SAMPLINGRATE: obj.getSamplingRate()}))
                  
         elif issubclass(cls, Image):
             fn = getImageLocation(obj)
@@ -161,7 +147,9 @@ class XmippViewer(Viewer):
         elif issubclass(cls, SetOfNormalModes):
             fn = obj.getFileName()
             objCommands = "'%s' '%s'" % (OBJCMD_NMA_PLOTDIST, OBJCMD_NMA_VMD)
-            self._views.append(ObjectView(self._project,  self.protocol.strId(), fn, obj.strId(), viewParams={OBJCMDS: objCommands}, **args))
+            self._views.append(ObjectView(self._project,  self.protocol.strId(),
+                                          fn, obj.strId(),
+                                          viewParams={OBJCMDS: objCommands}, **args))
 
         elif issubclass(cls, SetOfMovies):
             fn = obj.getFileName()
@@ -178,10 +166,6 @@ class XmippViewer(Viewer):
             
 
         elif issubclass(cls, MicrographsTiltPair):          
-#             fnU = obj.getUntilted().getFileName()
-#             fnT = obj.getTilted().getFileName()
-#             self._views.append(ObjectView(self._project.getName(), obj.strId(), fnU, **args))            
-#             self._views.append(ObjectView(self._project.getName(), obj.strId(), fnT, **args))
             labels = 'id enabled _untilted._filename _tilted._filename'
             self._views.append(ObjectView(self._project, obj.strId(), obj.getFileName(),
                                           viewParams={ORDER: labels, 
@@ -193,10 +177,10 @@ class XmippViewer(Viewer):
             labels = 'id enabled _untilted._filename _tilted._filename'
             self._views.append(ObjectView(self._project, obj.strId(), obj.getFileName(),
                                           viewParams={ORDER: labels, 
-                                                      VISIBLE: labels, RENDER:'_untilted._filename _tilted._filename',
+                                                      VISIBLE: labels,
+                                                      RENDER:'_untilted._filename _tilted._filename',
                                                       MODE: MODE_MD}))
 
-                            
         elif issubclass(cls, SetOfCoordinates):
             micSet = obj.getMicrographs()  # accessing mics to provide metadata file
             if micSet is None:
@@ -236,13 +220,17 @@ class XmippViewer(Viewer):
             self._views.append(ObjectView(self._project, obj.strId(), fn,
                                           viewParams={ORDER: labels, 
                                                       VISIBLE: labels, 
-                                                      'sortby': '_xmipp_zScore asc', RENDER:'_filename'}))
+                                                      'sortby': '_xmipp_zScore asc',
+                                                      RENDER:'_filename'}))
                
         elif issubclass(cls, SetOfVolumes):
             fn = obj.getFileName()
             labels = 'id enabled comment _filename '
             self._views.append(ObjectView(self._project, obj.strId(), fn,
-                                          viewParams={MODE: MODE_MD, ORDER: labels, VISIBLE: labels, RENDER: '_filename'}))
+                                          viewParams={MODE: MODE_MD,
+                                                      ORDER: labels,
+                                                      VISIBLE: labels,
+                                                      RENDER: '_filename'}))
         
         elif issubclass(cls, SetOfClasses2D):
             fn = obj.getFileName()
@@ -252,13 +240,18 @@ class XmippViewer(Viewer):
             fn = obj.getFileName()
             self._views.append(Classes3DView(self._project, obj.strId(), fn))
         
-        if issubclass(cls, XmippProtCTFMicrographs) and not obj.hasAttribute("outputCTF"):
-            mics = obj.inputMicrographs.get()
-            visualizeCTFObjs(obj, mics)
+        if issubclass(cls, XmippProtCTFMicrographs):
+            if obj.hasAttribute('outputCTF'):
+                ctfSet = obj.outputCTF
+            else:
+                mics = obj.inputMicrographs.get()
+                ctfSet = self.__createTemporaryCtfs(obj, mics)
 
-        elif obj.hasAttribute("outputCTF"):
-            self._visualize(obj.outputCTF)
-        
+            if ctfSet.isEmpty():
+                self._views.append(self.infoMessage("No CTF estimation has finished yet"))
+            else:
+                self._views.append(CtfView(self._project, ctfSet))
+
         elif issubclass(cls, SetOfCTF):
             self._views.append(CtfView(self._project, obj))
 

--- a/pyworkflow/em/viewer.py
+++ b/pyworkflow/em/viewer.py
@@ -144,13 +144,52 @@ class ObjectView(DataView):
         
     def getShowJParams(self):
         # mandatory to provide scipion params
-        params = DataView.getShowJParams(self) + ' --scipion %s %s %s'%(self.port, self.inputid, self.other)
+        params = DataView.getShowJParams(self) + ' --scipion %s %s %s' % (self.port, self.inputid, self.other)
         return params
     
     def show(self):
         showj.runJavaIJapp(self._memory, 'xmipp.viewer.scipion.ScipionViewer', self.getShowJParams(), env=self._env)
         
-        
+
+class CtfView(ObjectView):
+    """ Customized ObjectView for SetOfCTF objects . """
+    # All extra labels that we want to show if present in the CTF results
+    PSD_LABELS = ['_psdFile', '_xmipp_enhanced_psd',
+                  '_xmipp_ctfmodel_quadrant', '_xmipp_ctfmodel_halfplane'
+                 ]
+    EXTRA_LABELS = ['_ctffind4_ctfResolution', '_xmipp_ctfCritFirstZero',
+                    ' _xmipp_ctfCritCorr13', '_xmipp_ctfCritFitting',
+                    '_xmipp_ctfCritNonAstigmaticValidity',
+                    '_xmipp_ctfCritCtfMargin', '_xmipp_ctfCritMaxFreq'
+                   ]
+    def __init__(self, project, ctfSet, other='', **kwargs):
+        first = ctfSet.getFirstItem()
+
+        def existingLabels(labelList):
+            return ' '.join([l for l in labelList if first.hasAttribute(l)])
+
+        psdLabels = existingLabels(self.PSD_LABELS)
+        extraLabels = existingLabels(self.EXTRA_LABELS)
+        labels =  'id enabled comment %s _defocusU _defocusV ' % psdLabels
+        labels += '_defocusAngle _defocusRatio %s  _micObj._filename' % extraLabels
+        viewParams = {showj.MODE: showj.MODE_MD,
+                      showj.ORDER: labels,
+                      showj.VISIBLE: labels,
+                      showj.ZOOM: 50
+                     }
+
+        if psdLabels:
+            viewParams[showj.RENDER] = psdLabels
+
+        if first.hasAttribute('_ctffind4_ctfResolution'):
+            viewParams[showj.OBJCMDS] = "'%s'" % showj.OBJCMD_CTFFIND4
+
+        inputId = ctfSet.getObjId() or ctfSet.getFileName()
+        ObjectView.__init__(self, project,
+                            inputId, ctfSet.getFileName(), other,
+                            viewParams, **kwargs)
+
+
 class ClassesView(ObjectView):
     """ Customized ObjectView for SetOfClasses. """
     def __init__(self, project, inputid, path, other='', viewParams={}, **kwargs):

--- a/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
@@ -39,6 +39,9 @@ import xmipp.utils.XmippDialog;
 import xmipp.utils.XmippFileChooser;
 import xmipp.utils.XmippLabel;
 import xmipp.utils.XmippWindowUtil;
+import xmipp.ij.commons.XmippImageConverter;
+
+
 
 public class CTFAnalyzerJFrame extends JFrame implements ActionListener
 {
@@ -77,81 +80,74 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
     private final static Color COLOR_DIFFERENCE = Color.orange;
     private ImagePlus profileimp;
 
-        
 
 	public CTFAnalyzerJFrame(ImagePlus imp, String ctffile, String psdfile)
     {
-            try
-		{
-			
-			this.imp = imp;
-			this.psdfile = psdfile;
-            this.profileimp = new ImagePlus(psdfile);
-			ctfmodel = new CTFDescription(ctffile);
+
+        try
+        {
+            this.imp = imp;
+            this.psdfile = psdfile;
+            this.profileimp = XmippImageConverter.loadImage(psdfile);
+            ctfmodel = new CTFDescription(ctffile);
             double samplingRate = getSamplingRate(ctffile);
-			samples = imp.getWidth() / 2;
-			xvalues = getXValues(samples, samplingRate);
-			initComponents();
-                        
-		}
-		catch (Exception e)
-		{
-			throw new IllegalArgumentException(e);
-		}
+            samples = imp.getWidth() / 2;
+            xvalues = getXValues(samples, samplingRate);
+        initComponents();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
 	public CTFAnalyzerJFrame(ImagePlus imp, CTFDescription ctfdescription, String psdfile, double samplingRate)
 	{
-		try
-		{
-			
-			this.imp = imp;
-			this.psdfile = psdfile;
-                        this.profileimp = new ImagePlus(psdfile);
-			ctfmodel = ctfdescription;
-			samples = imp.getWidth() / 2;
-			xvalues = getXValues(samples, samplingRate);
-			initComponents();
-		}
-		catch (Exception e)
-		{
-			throw new IllegalArgumentException(e);
-		}
+        try
+        {
+            this.imp = imp;
+            this.psdfile = psdfile;
+            this.profileimp = XmippImageConverter.loadImage(psdfile);
+            ctfmodel = ctfdescription;
+            samples = imp.getWidth() / 2;
+            xvalues = getXValues(samples, samplingRate);
+            initComponents();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
 	}
         
-        private void initComponents()
-        {
-            setTitle("CTF Analyzer");
-            fc = new XmippFileChooser();
+    private void initComponents()
+    {
+        setTitle("CTF Analyzer");
+        fc = new XmippFileChooser();
 
-			constraints = new GridBagConstraints();
-			constraints.insets = new Insets(0, 5, 0, 5);
-			constraints.anchor = GridBagConstraints.NORTHWEST;
-			// constraints.fill = GridBagConstraints.HORIZONTAL;
-			setLayout(new GridBagLayout());
-			JPanel contentpn = new JPanel(new GridBagLayout());
-			contentpn.setBorder(BorderFactory.createEtchedBorder());
-			add(contentpn, XmippWindowUtil.getConstraints(constraints, 0, 0));
-			imagepn = new JPanel(new GridBagLayout());
-			imagepn.setBorder(BorderFactory.createTitledBorder("PSD Image"));
-			imageprofilepn = new CTFAnalyzerImagePane(imp, this);
-			imagepn.add(imageprofilepn, XmippWindowUtil.getConstraints(constraints, 0, 0));
-			contentpn.add(imagepn, XmippWindowUtil.getConstraints(constraints, 0, 0, 1));
+        constraints = new GridBagConstraints();
+        constraints.insets = new Insets(0, 5, 0, 5);
+        constraints.anchor = GridBagConstraints.NORTHWEST;
+        // constraints.fill = GridBagConstraints.HORIZONTAL;
+        setLayout(new GridBagLayout());
+        JPanel contentpn = new JPanel(new GridBagLayout());
+        contentpn.setBorder(BorderFactory.createEtchedBorder());
+        add(contentpn, XmippWindowUtil.getConstraints(constraints, 0, 0));
+        imagepn = new JPanel(new GridBagLayout());
+        imagepn.setBorder(BorderFactory.createTitledBorder("PSD Image"));
+        imageprofilepn = new CTFAnalyzerImagePane(imp, this);
+        imagepn.add(imageprofilepn, XmippWindowUtil.getConstraints(constraints, 0, 0));
+        contentpn.add(imagepn, XmippWindowUtil.getConstraints(constraints, 0, 0, 1));
 
-			initGraphicPanes();
-			contentpn.add(actionspn, XmippWindowUtil.getConstraints(constraints, 0, 1, 1, 1));
-			contentpn.add(graphicpn, XmippWindowUtil.getConstraints(constraints, 1, 0, 1, 3));
+        initGraphicPanes();
+        contentpn.add(actionspn, XmippWindowUtil.getConstraints(constraints, 0, 1, 1, 1));
+        contentpn.add(graphicpn, XmippWindowUtil.getConstraints(constraints, 1, 0, 1, 3));
 
-			JPanel actionspn = new JPanel();
-			exportbt = XmippWindowUtil.getTextButton("Export Graphics", this);
-			actionspn.add(exportbt, XmippWindowUtil.getConstraints(constraints, 0, 1));
+        JPanel actionspn = new JPanel();
+        exportbt = XmippWindowUtil.getTextButton("Export Graphics", this);
+        actionspn.add(exportbt, XmippWindowUtil.getConstraints(constraints, 0, 1));
 //			exportavgbt = XmippWindowUtil.getTextButton("Export Average Graphics", this);
 //			actionspn.add(exportavgbt, XmippWindowUtil.getConstraints(constraints, 1, 1));
-			add(actionspn, XmippWindowUtil.getConstraints(constraints, 0, 1));
-			enableDisplay();
-			pack();
-			setVisible(true);
-        }
+        add(actionspn, XmippWindowUtil.getConstraints(constraints, 0, 1));
+        enableDisplay();
+        pack();
+        setVisible(true);
+    }
 
 	private void initGraphicPanes()
 	{
@@ -257,9 +253,8 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
 
 				line = new Line(x0, y0, x1, y1);
 				imp.setRoi(line);
-                                profileimp.setRoi(line);
+                profileimp.setRoi(line);
 				// Get profile.
-                               
 				ProfilePlot profilePlot = new ProfilePlot(profileimp);
 				psdprofile_avgplot = profilePlot.getProfile();
 
@@ -312,7 +307,7 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
 
 		line = new Line(x0, y0, imageprofilepn.getX1(), imageprofilepn.getY1());
 		imp.setRoi(line);
-                profileimp.setRoi(line);
+        profileimp.setRoi(line);
 		psdprofileplot = new ProfilePlot(profileimp).getProfile();
 
 

--- a/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
@@ -32,6 +32,7 @@ import org.jfree.chart.plot.XYPlot;
 import org.jfree.chart.renderer.xy.XYItemRenderer;
 import org.jfree.data.xy.XYSeries;
 import org.jfree.data.xy.XYSeriesCollection;
+import xmipp.jni.ImageGeneric;
 import xmipp.jni.CTFDescription;
 import xmipp.jni.MDLabel;
 import xmipp.jni.MetaData;
@@ -86,12 +87,18 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
 
         try
         {
+            // JMRT: I don't know if imp is needed since the psdfile is read
             this.imp = imp;
             this.psdfile = psdfile;
-            this.profileimp = XmippImageConverter.loadImage(psdfile);
+            ImageGeneric psd = new ImageGeneric(psdfile);
+            // JMRT: Always read the PSD with 256 pixels, greater values break the GUI
+            psd.read(256, 256, ImageGeneric.FIRST_IMAGE);
+            this.profileimp = XmippImageConverter.readToImagePlus(psd);
+            this.imp = this.profileimp;
+            psd.destroy();
             ctfmodel = new CTFDescription(ctffile);
             double samplingRate = getSamplingRate(ctffile);
-            samples = imp.getWidth() / 2;
+            samples = this.imp.getWidth() / 2;
             xvalues = getXValues(samples, samplingRate);
         initComponents();
         } catch (Exception e) {
@@ -103,11 +110,17 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
 	{
         try
         {
+            // JMRT: I don't know if imp is needed since the psdfile is read
             this.imp = imp;
             this.psdfile = psdfile;
-            this.profileimp = XmippImageConverter.loadImage(psdfile);
+            ImageGeneric psd = new ImageGeneric(psdfile);
+            // JMRT: Always read the PSD with 256 pixels, greater values break the GUI
+            psd.read(256, 256, ImageGeneric.FIRST_IMAGE);
+            this.profileimp = XmippImageConverter.readToImagePlus(psd);
+            psd.destroy();
+            this.imp = this.profileimp;
             ctfmodel = ctfdescription;
-            samples = imp.getWidth() / 2;
+            samples = this.imp.getWidth() / 2;
             xvalues = getXValues(samples, samplingRate);
             initComponents();
         } catch (Exception e) {

--- a/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/ctf/CTFAnalyzerJFrame.java
@@ -82,20 +82,14 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
     private ImagePlus profileimp;
 
 
-	public CTFAnalyzerJFrame(ImagePlus imp, String ctffile, String psdfile)
-    {
 
+	public CTFAnalyzerJFrame(String psdEnhancedFile, String ctffile, String psdfile)
+    {
         try
         {
-            // JMRT: I don't know if imp is needed since the psdfile is read
-            this.imp = imp;
+            this.imp = this.getThumbnail(psdEnhancedFile);
             this.psdfile = psdfile;
-            ImageGeneric psd = new ImageGeneric(psdfile);
-            // JMRT: Always read the PSD with 256 pixels, greater values break the GUI
-            psd.read(256, 256, ImageGeneric.FIRST_IMAGE);
-            this.profileimp = XmippImageConverter.readToImagePlus(psd);
-            this.imp = this.profileimp;
-            psd.destroy();
+            this.profileimp = this.getThumbnail(psdfile);
             ctfmodel = new CTFDescription(ctffile);
             double samplingRate = getSamplingRate(ctffile);
             samples = this.imp.getWidth() / 2;
@@ -106,19 +100,13 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
         }
     }
 
-	public CTFAnalyzerJFrame(ImagePlus imp, CTFDescription ctfdescription, String psdfile, double samplingRate)
+	public CTFAnalyzerJFrame(String psdEnhancedFile, CTFDescription ctfdescription, String psdfile, double samplingRate)
 	{
         try
         {
-            // JMRT: I don't know if imp is needed since the psdfile is read
-            this.imp = imp;
+            this.imp = this.getThumbnail(psdEnhancedFile);
             this.psdfile = psdfile;
-            ImageGeneric psd = new ImageGeneric(psdfile);
-            // JMRT: Always read the PSD with 256 pixels, greater values break the GUI
-            psd.read(256, 256, ImageGeneric.FIRST_IMAGE);
-            this.profileimp = XmippImageConverter.readToImagePlus(psd);
-            psd.destroy();
-            this.imp = this.profileimp;
+            this.profileimp = this.getThumbnail(psdfile);
             ctfmodel = ctfdescription;
             samples = this.imp.getWidth() / 2;
             xvalues = getXValues(samples, samplingRate);
@@ -127,7 +115,24 @@ public class CTFAnalyzerJFrame extends JFrame implements ActionListener
             e.printStackTrace();
         }
 	}
-        
+
+    /* Load the image with a size of 256 pixels. */
+    private ImagePlus getThumbnail(String imagefile)
+    {
+        ImagePlus imp = null;
+        try
+        {
+        ImageGeneric img = new ImageGeneric(imagefile);
+        img.read(256, 256, ImageGeneric.FIRST_IMAGE);
+        imp = XmippImageConverter.readToImagePlus(img);
+        // Free the C-image memory
+        img.destroy();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return imp;
+    }
+
     private void initComponents()
     {
         setTitle("CTF Analyzer");

--- a/software/em/xmipp/java/src/xmipp/viewer/models/GalleryData.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/models/GalleryData.java
@@ -1745,24 +1745,30 @@ public class GalleryData {
             
             String psd = md.getPSDFile(id);
             String psden = md.getPSDEnhanced(id);
-            ImageGeneric img;
-            if(psden != null)
-                img = new ImageGeneric(psden);
-            else
-                img = new ImageGeneric(psd);
-            ImagePlus imp = XmippImageConverter.readToImagePlus(img);
-            
-            
-            if (profile) {
-                if( psden == null)
-                    new CTFAnalyzerJFrame(imp, md.getCTFDescription(id), psd, md.getEllipseCTF(id).getSamplingRate());
+
+            boolean noPsdEnhanced = (psden == null);
+            // Use the same PSD image in case no PSD enhanced
+
+            if (noPsdEnhanced)
+                psden = psd;
+
+            if (profile)
+            {
+                if (noPsdEnhanced)
+                    new CTFAnalyzerJFrame(psden, md.getCTFDescription(id), psd, md.getEllipseCTF(id).getSamplingRate());
                 else
-                    new CTFAnalyzerJFrame(imp, md.getCTFFile(id), psd);
-            } else {
+                    new CTFAnalyzerJFrame(psden, md.getCTFFile(id), psd);
+            }
+            else
+            {
+                ImageGeneric img = new ImageGeneric(psden);
+                ImagePlus imp = XmippImageConverter.readToImagePlus(img);
+                img.destroy();
                 EllipseCTF ctfparams = md.getEllipseCTF(id, imp.getWidth());
                 String sortfn = createSortFile(psd, row);
-                XmippUtil.showImageJ(Tool.VIEWER);// removed Toolbar.FREEROI
-                CTFRecalculateImageWindow ctfiw = new CTFRecalculateImageWindow(this, selection, imp, psd, ctfparams, ctfTasks, row, sortfn);
+                XmippUtil.showImageJ(Tool.VIEWER); // removed Toolbar.FREEROI
+                CTFRecalculateImageWindow ctfiw = new CTFRecalculateImageWindow(this, selection, imp, psd, ctfparams,
+                                                                                ctfTasks, row, sortfn);
             }
 
         } catch (Exception e) {

--- a/software/em/xmipp/java/src/xmipp/viewer/particlepicker/extract/ExtractPickerJFrame.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/particlepicker/extract/ExtractPickerJFrame.java
@@ -163,9 +163,7 @@ public class ExtractPickerJFrame extends ParticlePickerJFrame
 				String psd = getMicrograph().getPSD();
 				String ctf = getMicrograph().getCTF();
 				if (psd != null && ctf != null)
-					new CTFAnalyzerJFrame(getMicrograph().getPSDImage(), getMicrograph().getCTF(), getMicrograph().getPSD());
-                                
-
+					new CTFAnalyzerJFrame(psd, ctf, psd);
 			}
 		});
 		micrographsmd = new ExtractMicrographsTableModel();

--- a/software/em/xmipp/java/src/xmipp/viewer/particlepicker/training/gui/SupervisedPickerJFrame.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/particlepicker/training/gui/SupervisedPickerJFrame.java
@@ -628,7 +628,7 @@ public class SupervisedPickerJFrame extends ParticlePickerJFrame {
                     String ctf = getMicrograph().getCTF();
                     if (psd != null && ctf != null) {
                         try {
-                            new CTFAnalyzerJFrame(getMicrograph().getPSDImage(), getMicrograph().getCTF(), getMicrograph().getPSD());
+                            new CTFAnalyzerJFrame(psd, ctf, psd);
                         } catch (Exception ex) {
                             Logger.getLogger(SupervisedPickerJFrame.class.getName()).log(Level.SEVERE, null, ex);
                         }


### PR DESCRIPTION
Main fixes:
- SetOfCtf visualization is the same if you double click the object or in the Analyze Results.
- CtfView is now centralized and the labels are passed if they are present in the data (xmipp labels only appears when xmipp results)
- The display CTF fitting work as well for import ctf from ctffind4
- The PSD profile now works with ctf:mrc trick.

@azazellochg , could you check if these changes work for you? I tested import but from scipion-ctffind4, could you test for original-ctffind4 and for relion-ctffind4?