### PR TITLE
RELEASE V1.0.0  2016-02-20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## v1.0.0 (2016-02-01) Augusto
+## v1.0.0 (2016-02-15) Augusto
 
 - Allows to combine several EM software packages (~ 100 protocols):
   - All protocols from Xmipp 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 
-## v1.0.0 (2016-02-15) Augusto
+## v1.0.0 (2016-02-20) Augusto
 
 - Allows to combine several EM software packages (~ 100 protocols):
   - All protocols from Xmipp 

--- a/pyworkflow/em/convert.py
+++ b/pyworkflow/em/convert.py
@@ -75,7 +75,7 @@ class ImageHandler(object):
         
         return outLocation
     
-    def _existsLocation(self, location):
+    def existsLocation(self, location):
         """ Return True if a given location exists. 
         Location have the same meaning than in _convertToLocation.
         """
@@ -93,7 +93,7 @@ class ImageHandler(object):
         if ':' in fn:
             fn = fn.split(':')[0]
 
-        return fn
+        return os.path.exists(fn)
         
     def convert(self, inputObj, outputObj, dataType=None):
         """ Convert from one image to another.
@@ -128,7 +128,7 @@ class ImageHandler(object):
             n is the number of elements if stack.
         """
         
-        if self._existsLocation(locationObj):
+        if self.existsLocation(locationObj):
             
             location = self._convertToLocation(locationObj)
             fn = location[1]
@@ -258,6 +258,23 @@ class ImageHandler(object):
         """ Check if imgFn has an image extension. The function
         is implemented in the xmipp binding."""
         return xmipp.FileName(imgFn).isImage()
+
+    @classmethod
+    def getVolFileName(cls, location):
+        if isinstance(location, tuple):
+            fn = location[1]
+        elif isinstance(location, basestring):
+            fn = location
+        elif hasattr(location, 'getLocation'): #this include Image and subclasses
+            # In this case inputLoc should be a subclass of Image
+            fn = location.getLocation()[1]
+        else:
+            raise Exception('Can not match object %s to (index, location)' % type(location))
+
+        if fn.endswith('.mrc') or fn.endswith('.map'):
+            fn += ':mrc'
+
+        return fn
 
 
 def downloadPdb(pdbId, pdbFile, log=None):

--- a/pyworkflow/em/packages/relion/protocol_base.py
+++ b/pyworkflow/em/packages/relion/protocol_base.py
@@ -642,17 +642,20 @@ class ProtRelionBase(EMProtocol):
     
     def _summary(self):
         self._initialize()
-        iterMsg = 'Iteration %d' % self._lastIter()
-        if self.hasAttribute('numberOfIterations'):
-            iterMsg += '/%d' % self._getnumberOfIters()
-        summary = [iterMsg]
-        
-        if self._getInputParticles().isPhaseFlipped():
-            msg = "Your images have been ctf-phase corrected"
+
+        lastIter = self._lastIter()
+
+        if lastIter is not None:
+            iterMsg = 'Iteration %d' % lastIter
+            if self.hasAttribute('numberOfIterations'):
+                iterMsg += '/%d' % self._getnumberOfIters()
         else:
-            msg = "Your images have not been ctf-phase corrected"
-        
-        summary += [msg]
+            iterMsg = 'No iteration finished yet.'
+        summary = [iterMsg]
+
+        flip = '' if self._getInputParticles().isPhaseFlipped() else 'not '
+        flipMsg = "Your images have %sbeen ctf-phase corrected" % flip
+        summary.append(flipMsg)
         
         if self.doContinue:
             summary += self._summaryContinue()

--- a/pyworkflow/em/packages/spider/convert.py
+++ b/pyworkflow/em/packages/spider/convert.py
@@ -34,7 +34,7 @@ from pyworkflow.em.convert import ImageHandler
 from pyworkflow.utils.path import moveFile
 
 from spider import SpiderDocFile, runTemplate
-from os.path import splitext
+from os.path import splitext, split
    
     
 
@@ -95,12 +95,13 @@ def convertEndian(stackFn, stackSize):
         stackSize: the number of particles in the stack
     """
     fn, ext = splitext(stackFn)
+    fnDir, fnBase = split(fn)
     # Change to BigEndian
     runTemplate('cp_endian.spi', ext[1:], 
-              {'[particles]': fn + '@******', 
-               '[particles_big]': fn + '_big@******',
+              {'[particles]': fnBase + '@******',
+               '[particles_big]': fnBase + '_big@******',
                '[numberOfParticles]': stackSize
-               })
+               }, cwd=fnDir)
     moveFile(fn + '_big' + ext, stackFn)
     
     

--- a/pyworkflow/em/packages/spider/protocol/protocol_classify_diday.py
+++ b/pyworkflow/em/packages/spider/protocol/protocol_classify_diday.py
@@ -29,8 +29,8 @@ from protocol_classify_base import SpiderProtClassifyCluster
       
 
 class SpiderProtClassifyDiday(SpiderProtClassifyCluster):
-    """ Performs automatic clustering using Diday’s method and
-    Hierarchical Ascendant Classification (HAC) using Ward’s criterion
+    """ Performs automatic clustering using Diday's method and
+    Hierarchical Ascendant Classification (HAC) using Ward's criterion
     on factors produced by CA or PCA. Uses the Spider CL CLA program
     """
     _label = 'classify diday'

--- a/pyworkflow/em/packages/spider/protocol/protocol_classify_ward.py
+++ b/pyworkflow/em/packages/spider/protocol/protocol_classify_ward.py
@@ -30,7 +30,7 @@ from protocol_classify_base import SpiderProtClassifyCluster
 
 class SpiderProtClassifyWard(SpiderProtClassifyCluster):
     """ Finds clusters of images/elements in factor space
-    (or a selected subspace) by using Diday’s method of moving centers,
+    (or a selected subspace) by using Diday's method of moving centers,
     and applies hierarchical ascendant classification (HAC) (using
     Ward's method) to the resulting cluster centers.
     Uses the Spider CL HC program

--- a/pyworkflow/em/packages/xmipp3/__init__.py
+++ b/pyworkflow/em/packages/xmipp3/__init__.py
@@ -79,7 +79,8 @@ from protocol_helical_parameters import XmippProtHelicalParameters
 from protocol_kerdensom import XmippProtKerdensom
 from protocol_ml2d import XmippProtML2D
 from protocol_movie_alignment import ProtMovieAlignment
-from protocol_multireference_alignability import XmippProtMultiRefAlignability
+# FIXME: uncomment the following line when protocol ready for release
+#from protocol_multireference_alignability import XmippProtMultiRefAlignability
 from protocol_particle_pick_automatic import XmippParticlePickingAutomatic
 from protocol_particle_pick_consensus import XmippProtConsensusPicking
 from protocol_particle_pick import XmippProtParticlePicking 

--- a/pyworkflow/em/packages/xmipp3/protocol_break_symmetry.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_break_symmetry.py
@@ -32,8 +32,12 @@ import pyworkflow.em.metadata as md
 
  
 class XmippProtAngBreakSymmetry(ProtProcessParticles):
-    """ Classify particles according their similarity to the others
-    in order to detect outliers.
+    """
+    Given an input set of particles with angular assignment, find an
+    equivalent angular assignment for a given symmetry.
+
+    Be aware that input symmetry values follows Xmipp conventions as described in:
+    http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Symmetry
     """
     _label = 'break symmetry'
 

--- a/pyworkflow/em/packages/xmipp3/protocol_extract_particles.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_extract_particles.py
@@ -427,18 +427,23 @@ class XmippProtExtractParticles(ProtExtractParticles, XmippProtocol):
 
     #--------------------------- INFO functions -------------------------------------------- 
     def _validate(self):
-        validateMsgs = []
+        errors = []
         
         # doFlip can only be True if CTF information is available on picked micrographs
         if self.doFlip and not self.ctfRelations.hasValue():
-            validateMsgs.append('Phase flipping cannot be performed unless CTF information is provided.')
-            
+            errors.append('Phase flipping cannot be performed unless CTF information is provided.')
+
+        if self.doNormalize:
+            if self.backRadius > int(self.boxSize.get()/2):
+                errors.append("Background radius for normalization should be "
+                              "equal or less than half of the box size.")
+
         self._setupCtfProperties() # setup self.micKey among others
         if self.ctfRelations.hasValue() and self.micKey is None:
-            validateMsgs.append('Some problem occurs matching micrographs and CTF.\n'
+            errors.append('Some problem occurs matching micrographs and CTF.\n'
                                 'There were micrographs for which CTF was not found\n'
                                 'either using micName or micId.\n')
-        return validateMsgs
+        return errors
     
     def _citations(self):
         return ['Vargas2013b']

--- a/pyworkflow/em/packages/xmipp3/protocol_extract_particles_movies.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_extract_particles_movies.py
@@ -41,12 +41,14 @@ from pyworkflow.utils.path import cleanPath
 from pyworkflow.em.packages.xmipp3 import coordinateToRow, XmippMdRow
 
 
+
 class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
     """ Extract a set of Particles from each frame of a set of Movies.
     """
-    _label = 'movie extract particles' 
-    def __init__(self, **args):
-        ProtExtractMovieParticles.__init__(self, **args)
+    _label = 'movie extract particles'
+
+    def __init__(self, **kwargs):
+        ProtExtractMovieParticles.__init__(self, **kwargs)
         self.stepsExecutionMode = STEPS_PARALLEL
     
     #--------------------------- DEFINE param functions --------------------------------------------
@@ -60,10 +62,16 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
                       help='In pixels. The box size is the size of the boxed particles, '
                       'actual particles may be smaller than this.')
         form.addParam('applyAlignment', BooleanParam, default=False,
-                      label='Apply alignments to extract?')
-
+                      label='Apply alignments to extract?',
+                      help='If the input movies contains frames alignment, '
+                           'you decide whether to use that information '
+                           'for extracting the particles taking into account '
+                           'the shifts between frames.')
         line = form.addLine('Frames range',
-                      help='')
+                      help='Specify the frames range to extract particles from.\n'
+                           '  _First_: 1 will be the first frame in the movie.\n'
+                           '  _Last_: For any value <= 0, the range will go until '
+                           'the last frame. ')
         line.addParam('firstFrame', IntParam, default=1,
                       label='First')
         line.addParam('lastFrame',  IntParam, default=0,

--- a/pyworkflow/em/packages/xmipp3/protocol_multireference_alignability.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_multireference_alignability.py
@@ -42,11 +42,11 @@ from pyworkflow.em.packages.xmipp3.convert import (writeSetOfParticles,
 
 class XmippProtMultiRefAlignability(ProtAnalysis3D):
     """    
-    Reconstruct a volume using Xmipp_reconstruct_fourier from a given set of particles.
-    The alignment parameters will be converted to a Xmipp xmd file
-    and used as direction projections to reconstruct.
+    Performs soft alignment validation of a set of particles confronting them
+    against a given 3DEM map. This protocol produces particle alignment
+    precision and accuracy parameters.
     """
-    _label = 'multireference_aligneability'
+    _label = 'multireference aligneability'
     
     def __init__(self, *args, **kwargs):
         ProtAnalysis3D.__init__(self, *args, **kwargs)

--- a/pyworkflow/em/packages/xmipp3/protocol_projmatch/projmatch_form.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_projmatch/projmatch_form.py
@@ -241,17 +241,16 @@ def _defineProjectionMatchingParams(self, form):
     
     form.addParam('maxChangeOffset', NumericListParam, default='1000 10 5', 
                  label='Maximum change in origin offset', expertLevel=LEVEL_ADVANCED,
-                 help=""" If set to 1, this option will result to a Gaussian perturbation to the 
-    evenly sampled projection directions of the reference library. 
-    This may serve to decrease the effects of model bias.
-    You may specify this option for each iteration. 
-    This can be done by a sequence of numbers (for instance, "1 1 0" 
-    specifies 3 iterations, the first two set the value to 1 
-    and the last to 0. An alternative compact notation 
-    is ("2x1 0", i.e.,
-    2 iterations with value 1, and 1 with value 0).
+                 help=""" Maximum shift allowed per iteration.
+    You may specify this option for each iteration.
+    This can be done by a sequence of numbers (for instance, "1000 10 5"
+    specifies 3 iterations, the first two set the value to 1000
+    (almost no restriction) and the last to 5.
+    An alternative compact notation
+    is ("2x1000 5", i.e.,
+    2 iterations with value 1000, and 1 with value 5).
     *Note:* if there are less values than iterations the last value is reused
-    *Note:* if there are more values than iterations the extra value are ignored
+    *Note:* if there are more values than iterations the extra values are ignored
     """)          
     
     form.addParam('search5DShift', NumericListParam, default='4x5 0', 

--- a/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
@@ -75,8 +75,8 @@ class XmippProtWriteTestP(ProtProcessParticles):
         nproc = self.numberOfMpi.get()
         #nT=self.numberOfThreads.get()
 
-        self.runJob('xmipp_image_operate',
-                    params, numberOfMpi=nproc,cwd=self._getExtraPath())
+        self.runJob('xmipp_image_operate', params, numberOfMpi=1,
+                    cwd=self._getExtraPath())
 
     def testWriteValidate(self):
         img = Image()

--- a/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
@@ -31,6 +31,7 @@ from pyworkflow.em.protocol import ProtProcessParticles
 from pyworkflow.protocol.constants import STEPS_PARALLEL
 from pyworkflow.protocol.params import IntParam
 
+
 class XmippProtWriteTestP(ProtProcessParticles):
     """    
     using mpi write data to a large file (python level)
@@ -51,33 +52,44 @@ class XmippProtWriteTestP(ProtProcessParticles):
 
     #--------------------------- INSERT steps functions --------------------------------------------
     def _insertAllSteps(self):
-       stepId = self._insertFunctionStep('testWriteStep', self.nframes.get())
+       stepId = self._insertFunctionStep('createReferenceStep')
        pre=[]
        for counter in range(self.nframes.get(),0,-1):
-            id = self._insertFunctionStep('testWriteStep', counter, prerequisites=[stepId] )
-            pre.append(id)
-       stepId = self._insertFunctionStep('testWriteValidate',  prerequisites=pre)
-       #check step...
+            wid = self._insertFunctionStep('testWriteStep', counter, prerequisites=[stepId] )
+            pre.append(wid)
+       self._insertFunctionStep('testWriteValidate',  prerequisites=pre)
 
-    def testWriteStep(self, counter):
+    def createReferenceStep(self):
         #change directory
         #cwd=self._getExtraPath()
         #os.chdir(cwd)
-	img = Image()
-	img.setDataType(DT_FLOAT)
-	img.resize(self.xDim.get(), self.yDim.get())
-	img.initConstant(counter)
-	img.write("%d@%s"%(counter,os.path.join(self._getExtraPath(),"kk.mrcs")))
+	    img = Image()
+        img.setDataType(DT_FLOAT)
+        img.resize(self.xDim.get(), self.yDim.get())
+        img.initConstant(1.)
+        img.write(self._getExtraPath("reference.mrc"))
+        img.write('%d@%s' % (self.nframes, self._getExtraPath('kk.mrcs')))
+
+    def testWriteStep(self, counter):
+        params =  ' -i reference.mrc '
+        params += ' -o %d@kk.mrcs' %counter
+        params += ' --mult %d' % counter
+        #change to directory
+        nproc = self.numberOfMpi.get()
+        #nT=self.numberOfThreads.get()
+
+        self.runJob('xmipp_image_operate',
+                    params, numberOfMpi=nproc,cwd=self._getExtraPath())
 
     def testWriteValidate(self):
-	img = Image()
+        img = Image()
         for counter in range(self.nframes.get(),0,-1):
-	    img.read("%d@%s"%(counter,os.path.join(self._getExtraPath(),"kk.mrcs")))
+            img.read("%d@%s"%(counter,os.path.join(self._getExtraPath(),"kk.mrcs")))
             mean, dev, min, max = img.computeStats()
             if (min == max) and (min == counter) and (dev == 0):
-                print("frame %d ok"%counter)
+                print("frame %d ok" % counter)
             else:
-                print("frame %d no OK mean dev, min max"%counter, mean,dev,min,max)
+                print("frame %d no OK mean dev, min max" % counter, mean,dev,min,max)
                 break
     #--------------------------- INFO functions --------------------------------------------
     def _validate(self):

--- a/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_write_testP.py
@@ -60,10 +60,7 @@ class XmippProtWriteTestP(ProtProcessParticles):
        self._insertFunctionStep('testWriteValidate',  prerequisites=pre)
 
     def createReferenceStep(self):
-        #change directory
-        #cwd=self._getExtraPath()
-        #os.chdir(cwd)
-	    img = Image()
+        img = Image()
         img.setDataType(DT_FLOAT)
         img.resize(self.xDim.get(), self.yDim.get())
         img.initConstant(1.)

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -186,7 +186,6 @@ class XmippViewer(Viewer):
             if micSet is None:
                 raise Exception('visualize: SetOfCoordinates has no micrographs set.')
             
-
             mdFn = getattr(micSet, '_xmippMd', None)
             if mdFn:
                 fn = mdFn.get()
@@ -194,23 +193,16 @@ class XmippViewer(Viewer):
                 fn = self._getTmpPath(micSet.getName() + '_micrographs.xmd')
                 writeSetOfMicrographs(micSet, fn)
             tmpDir = self._getTmpPath(obj.getName())
-            if os.path.exists(tmpDir):
-                r = dialog.askYesNoCancel("Question", 
-                                   "It seems that you have edited this SetOfCoordinates before.\n"
-                                   "Do you wish to load the changes?\n\n"
-                                   "_Note_: If you choose *No*, the original coordinates will be loaded\n"
-                                   " and previous changes will be lost.", self._tkRoot)
-                
-                if r == dialog.RESULT_CANCEL:
-                    return
-                elif r == dialog.RESULT_NO:
-                    cleanPath(tmpDir)
-                    makePath(tmpDir)
-                    writeSetOfCoordinates(tmpDir, obj)# always write set of coordinates instead of reading pos dir, that could have changed
-            else:
-                makePath(tmpDir)
-                writeSetOfCoordinates(tmpDir, obj)# always write set of coordinates instead of reading pos dir, that could have changed
-            
+            cleanPath(tmpDir)
+            makePath(tmpDir)
+            # FIXME: (JMRT) We are always writing the SetOfCoordinates and removing
+            # the tmpDir, we need to take into account if the user have pick
+            # some particles in the tmpDir and have not save them, that now
+            # will loose all picked partices.
+            # A possible solution could be to alert that changes have not been
+            # written during modification of tmpDir or create a new Xmipp picking
+            # protocol to continue picking later without loosing the coordinates.
+            writeSetOfCoordinates(tmpDir, obj)
             self._views.append(CoordinatesObjectView(self._project, fn, tmpDir, self.protocol))
 
         elif issubclass(cls, SetOfParticles):

--- a/pyworkflow/em/protocol/protocol_ctf_assign.py
+++ b/pyworkflow/em/protocol/protocol_ctf_assign.py
@@ -95,7 +95,7 @@ class ProtCTFAssign(ProtCTFMicrographs):
             if hasMicName:
                 ctfName = ctf.getMicrograph().getMicName()
             else:
-                ctfName = ctf.getMicrograph().getMicId()
+                ctfName = ctf.getMicrograph().getObjId()
 #             print "ctf: ", ctf.printAll(), ctfName
             ctfDict[ctfName] = ctf.clone()
         

--- a/pyworkflow/em/protocol/protocol_sets.py
+++ b/pyworkflow/em/protocol/protocol_sets.py
@@ -48,7 +48,7 @@ class ProtUnionSet(ProtSets):
     selected sets. It will validate that all sets are of the
     same type of elements (Micrographs, Particles or Volumes) 
     """
-    _label = 'union sets'
+    _label = 'join sets'
     _unionTypes = ['Particles', 
                    'Micrographs', 
                    'CTFs', 

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -1249,7 +1249,8 @@ class FormWindow(Window):
         allowThreads = self.protocol.allowThreads # short notation
         allowMpi = self.protocol.allowMpi # short notation
         numberOfMpi = self.protocol.numberOfMpi.get() 
-        numberOfThreads = self.protocol.numberOfThreads.get() 
+        numberOfThreads = self.protocol.numberOfThreads.get()
+        mode = self.protocol.stepsExecutionMode
         
         if allowThreads or allowMpi:
             self._createHeaderLabel(runFrame, Message.LABEL_PARALLEL, bold=True, sticky='ne', row=r, pady=0)
@@ -1257,9 +1258,17 @@ class FormWindow(Window):
             r2 = 0
             c2 = 0
             sticky = 'ne'
-            if self.protocol.stepsExecutionMode == params.STEPS_PARALLEL:
+
+            # FIXME: JMRT (2015-02-08) We are having problems with MPI and
+            # FIXME:    protocols parallelized with steps, for now use only threads
+            if mode == params.STEPS_PARALLEL:
+                mode = None
+                allowMpi = False
+                allowThread = True
+
+            if mode == params.STEPS_PARALLEL:
                 self.procTypeVar = tk.StringVar()
-                
+
                 if allowThreads and allowMpi:
                     if numberOfMpi > 1:
                         procs = numberOfMpi

--- a/pyworkflow/object.py
+++ b/pyworkflow/object.py
@@ -818,7 +818,7 @@ class List(Object, list):
         return list.__len__(self)
     
     def isEmpty(self):
-        return len(self) > 0
+        return len(self) == 0
     
     def clear(self):
         del self[:]
@@ -973,6 +973,9 @@ class Set(OrderedObject):
     def getSize(self):
         """Return the number of images"""
         return self._size.get()
+
+    def isEmpty(self):
+        return self.getSize() == 0
     
     def getFileName(self):
         if len(self._mapperPath):

--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -16,6 +16,7 @@ import pyworkflow.em.packages.eman2.convert as e2convert
 from pyworkflow.em.protocol import EMProtocol
 
 import pyworkflow.em.metadata as md
+from pyworkflow.em.convert import ImageHandler
 
 
 
@@ -34,7 +35,28 @@ class TestImage(unittest.TestCase):
 
         # Check that setFileName-getFileName is working properly        
         self.assertEqual(fn, mic.getFileName())
-        
+
+
+class TestImageHandler(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        setupTestOutput(cls)
+        cls.dataset = DataSet.getDataSet('xmipp_tutorial')
+
+    def testExistLocation(self):
+        volFn = self.dataset.getFile('volumes/volume_1_iter_002.mrc')
+
+        ih = ImageHandler()
+        # Test the volume filename exists
+        self.assertTrue(ih.existsLocation(volFn))
+        # Test missing filename
+        self.assertFalse(ih.existsLocation(volFn.replace('.mrc', '_fake.mrc')))
+        # Test the :mrc is append when used as volume
+        newFn = ih.getVolFileName(volFn)
+        self.assertEqual(newFn, volFn + ":mrc")
+        # Test that the new filename still exists even with the :mrc suffix
+        self.assertTrue(ih.existsLocation(newFn))
+
         
 class TestSetOfMicrographs(BaseTest):
     

--- a/pyworkflow/tests/em/protocols/test_protocols_grigoriefflab.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_grigoriefflab.py
@@ -167,7 +167,7 @@ class TestBrandeisCtffind(TestBrandeisBase):
         cls.protImport = cls.runImportMicrographBPV(cls.micFn)
     
     def testCtffind(self):
-        protCTF = ProtCTFFind(useCftfind4=False)
+        protCTF = ProtCTFFind(useCtffind4=False)
         protCTF.inputMicrographs.set(self.protImport.outputMicrographs)
         protCTF.ctfDownFactor.set(2)
         protCTF.numberOfThreads.set(4)
@@ -182,7 +182,7 @@ class TestBrandeisCtffind(TestBrandeisBase):
             self.assertAlmostEquals(ctfModel.getMicrograph().getSamplingRate(), 2.474, delta=0.001)
 
     def testCtffind2(self):
-        protCTF = ProtCTFFind(useCftfind4=False)
+        protCTF = ProtCTFFind(useCtffind4=False)
         protCTF.inputMicrographs.set(self.protImport.outputMicrographs)
         protCTF.numberOfThreads.set(4)
         self.proj.launchProtocol(protCTF, wait=True)

--- a/scipion
+++ b/scipion
@@ -40,7 +40,7 @@ except ImportError:
 
 __version__ = 'v1.0.0'
 __nickname__ = 'Augusto'
-__releasedate__ = '2016-02-02'
+__releasedate__ = '2016-08-02'
 
 
 # This script tries to run ok with any python version. So we cannot

--- a/scipion
+++ b/scipion
@@ -40,7 +40,7 @@ except ImportError:
 
 __version__ = 'v1.0.0'
 __nickname__ = 'Augusto'
-__releasedate__ = '2016-02-09'
+__releasedate__ = '2016-02-15'
 
 
 # This script tries to run ok with any python version. So we cannot

--- a/scipion
+++ b/scipion
@@ -40,7 +40,7 @@ except ImportError:
 
 __version__ = 'v1.0.0'
 __nickname__ = 'Augusto'
-__releasedate__ = '2016-02-15'
+__releasedate__ = '2016-02-20'
 
 
 # This script tries to run ok with any python version. So we cannot

--- a/scipion
+++ b/scipion
@@ -40,7 +40,7 @@ except ImportError:
 
 __version__ = 'v1.0.0'
 __nickname__ = 'Augusto'
-__releasedate__ = '2016-08-02'
+__releasedate__ = '2016-02-09'
 
 
 # This script tries to run ok with any python version. So we cannot


### PR DESCRIPTION
Summary:
- Computed phaseShifts in CTFFIND4, updated references
- Centralized viewer of SetOfCTF for both xmipp and ctffind, and the same from Analyze Results or double click on results.
- Fixed problem with ctf:mrc extension of PSD and bigger than 256 pixels
- Validations on relion viewers and on extract particles
- Used shorter name to run Spider script