### PR TITLE
Stop adding new lines in textboxes + ascii error in data view.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,3 +80,6 @@ static/
 /config.log
 /Debug/
 /bin/
+
+# Ignore version file
+.devel_version

--- a/pyworkflow/gui/dialog.py
+++ b/pyworkflow/gui/dialog.py
@@ -378,7 +378,7 @@ class EditObjectDialog(Dialog):
         self.textComment = Text(bodyFrame, height=self.commentHeight, 
                          width=self.commentWidth)
         self.textComment.setReadOnly(False)
-        self.textComment.addText(self.valueComment)
+        self.textComment.setText(self.valueComment)
         self.textComment.grid(row=1, column=1, sticky='news', padx=5, pady=5)
         self.initial_focus = self.textComment
         

--- a/pyworkflow/gui/project/viewdata.py
+++ b/pyworkflow/gui/project/viewdata.py
@@ -329,7 +329,7 @@ class ProjectDataView(tk.Frame):
 
 
         if obj.getObjComment():
-            self._infoText.addText('*Comments:* ' + str(obj.getObjComment()))
+            self._infoText.addText('*Comments:* ' + obj.getObjComment())
         self._infoText.setReadOnly(True)
         
     def _onClick(self, e=None):

--- a/pyworkflow/gui/text.py
+++ b/pyworkflow/gui/text.py
@@ -172,7 +172,12 @@ class Text(tk.Text, Scrollable):
         self.delete(0.0, tk.END)
 
     def getText(self):
-        return self.get(0.0, tk.END)
+
+        textWithNewLine = self.get(0.0, tk.END)
+
+        # Remove the last new line
+        return textWithNewLine.rstrip('\n')
+
     
     def setText(self, text):
         """ Replace the current text with new one. """


### PR DESCRIPTION
Objects comments were added new lines on each update. Now final new lines are trimmed in any text in a Text box.

Allow ascii characters in data vie summary.

This closes #353 