### PR TITLE
the conditional was restored as it is in v1.0 branch. 

### DIFF
--- a/software/em/xmipp/libraries/data/image_operate.cpp
+++ b/software/em/xmipp/libraries/data/image_operate.cpp
@@ -478,7 +478,7 @@ void ProgOperate::readParams()
             isValue = false;
             fn2 = file_or_value;
             md2.read(fn2);
-            if (md2.isMetadataFile)
+            if (md2.size() > 1)
             {
                 if (mdInSize != md2.size())
                     REPORT_ERROR(ERR_MD, "Both metadatas operands should be of same size.");


### PR DESCRIPTION
This is related with #466  issue. Now, there is a bug when the object is a metadata with one element. We need to fix it.