### PR TITLE
Check pid for protocol status

### DIFF
--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -513,6 +513,7 @@ class ProtocolsView(tk.Frame):
     This extended tk.Frame is what will appear when Protocols is on.
     """
 
+    RUNS_CANVAS_NAME = "runs_canvas"
     def __init__(self, parent, windows, **args):
         tk.Frame.__init__(self, parent, **args)
         # Load global configuration
@@ -934,7 +935,7 @@ class ProtocolsView(tk.Frame):
     def createRunsGraph(self, parent):
         self.runsGraphCanvas = pwgui.Canvas(parent, width=400, height=400, 
                                 tooltipCallback=self._runItemTooltip,
-                                tooltipDelay=1000)
+                                tooltipDelay=1000, name=ProtocolsView.RUNS_CANVAS_NAME, takefocus=True)
 
         self.runsGraphCanvas.onClickCallback = self._runItemClick
         self.runsGraphCanvas.onDoubleClickCallback = self._runItemDoubleClick
@@ -1275,6 +1276,8 @@ class ProtocolsView(tk.Frame):
         
     def _runItemClick(self, item=None):
 
+        self.runsGraphCanvas.focus_set()
+
         # Get last selected item for tree or graph
         if self.runsView == VIEW_LIST:
             prot = self.project.mapper.selectById(int(self.runsTree.getFirst()))
@@ -1582,7 +1585,7 @@ class ProtocolsView(tk.Frame):
         widget = self.focus_get()
 
         # If it's the search box
-        if str(widget).endswith(SEARCH_BOX_NAME):
+        if not str(widget).endswith(ProtocolsView.RUNS_CANVAS_NAME):
             return
 
         protocols = self._getSelectedProtocols()

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -41,6 +41,7 @@ import pyworkflow.gui as pwgui
 import pyworkflow.em as em
 from pyworkflow.em.wizard import ListTreeProvider
 from pyworkflow.gui.dialog import askColor, ListDialog
+from pyworkflow.gui.text import SEARCH_BOX_NAME
 from pyworkflow.viewer import DESKTOP_TKINTER, ProtocolViewer
 from pyworkflow.utils.properties import Message, Icon, Color
 
@@ -1576,6 +1577,14 @@ class ProtocolsView(tk.Frame):
         self._scheduleRunsUpdate()
         
     def _deleteProtocol(self):
+
+        # get the widget with the focus
+        widget = self.focus_get()
+
+        # If it's the search box
+        if str(widget).endswith(SEARCH_BOX_NAME):
+            return
+
         protocols = self._getSelectedProtocols()
 
         if len(protocols) == 0:

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -933,7 +933,7 @@ class ProtocolsView(tk.Frame):
     def createRunsGraph(self, parent):
         self.runsGraphCanvas = pwgui.Canvas(parent, width=400, height=400, 
                                 tooltipCallback=self._runItemTooltip,
-                                tooltipDelay=1000, name=ProtocolsView.RUNS_CANVAS_NAME, takefocus=True)
+                                tooltipDelay=1000, name=ProtocolsView.RUNS_CANVAS_NAME, takefocus=True, highlightthickness=0)
 
         self.runsGraphCanvas.onClickCallback = self._runItemClick
         self.runsGraphCanvas.onDoubleClickCallback = self._runItemDoubleClick

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -41,10 +41,8 @@ import pyworkflow.gui as pwgui
 import pyworkflow.em as em
 from pyworkflow.em.wizard import ListTreeProvider
 from pyworkflow.gui.dialog import askColor, ListDialog
-from pyworkflow.gui.text import SEARCH_BOX_NAME
 from pyworkflow.viewer import DESKTOP_TKINTER, ProtocolViewer
 from pyworkflow.utils.properties import Message, Icon, Color
-
 
 from constants import STATUS_COLORS
 

--- a/pyworkflow/gui/text.py
+++ b/pyworkflow/gui/text.py
@@ -42,8 +42,6 @@ from pyworkflow.utils import (HYPER_BOLD, HYPER_ITALIC, HYPER_LINK1, HYPER_LINK2
 from pyworkflow.utils.properties import Message, Color, Icon
 
 
-SEARCH_BOX_NAME = "log_searchbox"
-
 # Define a function to open files cleanly in a system-dependent way
 if sys.platform.startswith('darwin'):  # macs use the "open" command
     _open_cmd = lambda path: subprocess.Popen(['open', path])
@@ -518,7 +516,7 @@ class TextFileViewer(tk.Frame):
         self.searchVar = tk.StringVar()
         if self._allowSearch:
             tk.Label(right, text='Search:').grid(row=0, column=3, padx=5)
-            self.searchEntry = tk.Entry(right, textvariable=self.searchVar, name=SEARCH_BOX_NAME)
+            self.searchEntry = tk.Entry(right, textvariable=self.searchVar)
             self.searchEntry.grid(row=0, column=4, sticky='ew', padx=5)
             btn = IconButton(right, "Search", Icon.ACTION_SEARCH, tooltip=Message.TOOLTIP_SEARCH,
                              command=self.findText, bg=None)

--- a/pyworkflow/gui/text.py
+++ b/pyworkflow/gui/text.py
@@ -42,6 +42,8 @@ from pyworkflow.utils import (HYPER_BOLD, HYPER_ITALIC, HYPER_LINK1, HYPER_LINK2
 from pyworkflow.utils.properties import Message, Color, Icon
 
 
+SEARCH_BOX_NAME = "log_searchbox"
+
 # Define a function to open files cleanly in a system-dependent way
 if sys.platform.startswith('darwin'):  # macs use the "open" command
     _open_cmd = lambda path: subprocess.Popen(['open', path])
@@ -516,7 +518,7 @@ class TextFileViewer(tk.Frame):
         self.searchVar = tk.StringVar()
         if self._allowSearch:
             tk.Label(right, text='Search:').grid(row=0, column=3, padx=5)
-            self.searchEntry = tk.Entry(right, textvariable=self.searchVar)
+            self.searchEntry = tk.Entry(right, textvariable=self.searchVar, name=SEARCH_BOX_NAME)
             self.searchEntry.grid(row=0, column=4, sticky='ew', padx=5)
             btn = IconButton(right, "Search", Icon.ACTION_SEARCH, tooltip=Message.TOOLTIP_SEARCH,
                              command=self.findText, bg=None)

--- a/pyworkflow/project.py
+++ b/pyworkflow/project.py
@@ -845,7 +845,7 @@ class Project(object):
         from pyworkflow.protocol.launch import _isLocal
         pid = protocol.getPid()
 
-        if (protocol.isActive() and _isLocal(protocol)
+        if (protocol.isRunning() and _isLocal(protocol)
             and not protocol.useQueue()
             and not pwutils.isProcessAlive(pid)):
             protocol.setFailed("Process %s not found running on the machine. "

--- a/pyworkflow/project.py
+++ b/pyworkflow/project.py
@@ -381,12 +381,8 @@ class Project(object):
                                                  protocol.getDbPath(),
                                                  protocol.getObjId())
 
-                # FIXME: It seems that checkPid is not working for some cases
-                # FIXME: Coss reported that some protocols running are reported
-                # FIXME: as failed and not further processing can be done
-                # JMRT: So I will comment the following lines for now
-                #if checkPid:
-                #    self.checkPid(prot2)
+                if checkPid:
+                    self.checkPid(prot2)
 
                 # Copy is only working for db restored objects
                 protocol.setMapper(self.mapper)

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -967,6 +967,7 @@ class Protocol(Step):
         
         self.info(greenStr('RUNNING PROTOCOL -----------------'))
         self._pid.set(os.getpid())
+        self.info('          PID: %s' % self._pid)
         self.info('      Scipion: %s' % os.environ['SCIPION_VERSION'])
         self.info('   currentDir: %s' % os.getcwd())
         self.info('   workingDir: %s' % self.workingDir)

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -33,6 +33,8 @@ import os.path
 import resource
 from subprocess import check_call
 
+from psutil import NoSuchProcess
+
 from utils import greenStr, envVarOn
 
 
@@ -118,8 +120,8 @@ def isProcessAlive(pid):
 
     import psutil
     try:
-        proc = psutil.Process(pid.get())
+        proc = psutil.Process(pid)
         return proc.is_running()
-    except:
+    except NoSuchProcess, e:
         return False
 

--- a/pyworkflow/utils/process.py
+++ b/pyworkflow/utils/process.py
@@ -33,8 +33,6 @@ import os.path
 import resource
 from subprocess import check_call
 
-from psutil import NoSuchProcess
-
 from utils import greenStr, envVarOn
 
 
@@ -122,6 +120,6 @@ def isProcessAlive(pid):
     try:
         proc = psutil.Process(pid)
         return proc.is_running()
-    except NoSuchProcess, e:
+    except psutil.NoSuchProcess, e:
         return False
 

--- a/software/em/xmipp/java/src/xmipp/viewer/models/MetadataTableModel.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/models/MetadataTableModel.java
@@ -483,13 +483,13 @@ public class MetadataTableModel extends MetadataGalleryTableModel {
 
             final String columnName = data.labels.get(sortColumnIndex).labelName;
 
-            column.setHeaderValue( "⌛ " + columnName);
+            column.setHeaderValue( "\u231B " + columnName);
             Runnable sort = new Runnable() {
                 @Override
                 public void run() {
 
                     data.sortMd(data.labels.get(sortColumnIndex), ascending);
-                    column.setHeaderValue((ascending? "▲ ": "▼ ")+columnName);
+                    column.setHeaderValue((ascending? "\u25B2 ": "\u25BC ")+columnName);
                     table.getTableHeader().repaint();
                     clearSelection();
                     updateTableSelection(table);

--- a/software/em/xmipp/java/src/xmipp/viewer/models/MetadataTableModel.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/models/MetadataTableModel.java
@@ -483,12 +483,14 @@ public class MetadataTableModel extends MetadataGalleryTableModel {
 
             final String columnName = data.labels.get(sortColumnIndex).labelName;
 
+            //column.setHeaderValue( "⌛ " + columnName);
             column.setHeaderValue( "\u231B " + columnName);
             Runnable sort = new Runnable() {
                 @Override
                 public void run() {
 
                     data.sortMd(data.labels.get(sortColumnIndex), ascending);
+                    //column.setHeaderValue((ascending? "▲ ": "▼ ")+columnName);
                     column.setHeaderValue((ascending? "\u25B2 ": "\u25BC ")+columnName);
                     table.getTableHeader().repaint();
                     clearSelection();


### PR DESCRIPTION
Now it's checking properly the PID.
Also check only against running status, leaving outside the rest active ones(launched, interactive).
Additionally: Do not try to remove a protocol if delete is pressed while on the search box (the one in the logs tab).


Closes #183 
Closes #511 

Use \u format for unicode special characters, since the characters it self  generates compiling error in javac when the locales are not set properly.