### PR TITLE
fix workflow_betagal1.json

### DIFF
--- a/config/workflows/workflow_betagal1.json
+++ b/config/workflows/workflow_betagal1.json
@@ -14,10 +14,10 @@
         "voltage": 300.0,
         "sphericalAberration": 2.0,
         "amplitudeContrast": 0.1,
-        "magnification": 50000,
+        "magnification": 39548,
         "samplingRateMode": 0,
         "samplingRate": 3.54,
-        "scannedPixelSize": 7.0,
+        "scannedPixelSize": 14.0,
         "gainFile": null
     },
     {


### PR DESCRIPTION
a minor correction. Betagal dataset is 3.54A/px from 14um Falcon II, giving 39548 magnification