### PR TITLE
Re-factored how Object-Commands are handled

### DIFF
--- a/pyworkflow/em/packages/eman2/protocol_initialmodel.py
+++ b/pyworkflow/em/packages/eman2/protocol_initialmodel.py
@@ -153,7 +153,7 @@ class EmanProtInitModel(ProtInitialVolume):
             summary.append("Output volumes not ready yet.")
         else:
             summary.append("Input Images: %s" % self.inputSet.get().getNameId())
-            summary.append("Output initials volumes: %s" % self.outputVolumes.get())
+            summary.append("Output initial volumes: %s" % self.outputVolumes.getSize())
         return summary
     
     #--------------------------- UTILS functions --------------------------------------------

--- a/pyworkflow/em/packages/gctf/viewer.py
+++ b/pyworkflow/em/packages/gctf/viewer.py
@@ -1,7 +1,8 @@
 # **************************************************************************
 # *
-# * Authors:     Josue Gomez Blanco (jgomez@cnb.csic.es)
-# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# * Authors:     Grigory Sharov (sharov@igbmc.fr)
+# *
+# * L'Institut de genetique et de biologie moleculaire et cellulaire (IGBMC)
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -19,21 +20,24 @@
 # * 02111-1307  USA
 # *
 # *  All comments concerning this program package may be sent to the
-# *  e-mail address 'jgomez@cnb.csic.es'
+# *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-"""
-Visualization of the results of the Gctf.
-"""
 
 import os
 from os.path import exists
+
+from pyworkflow.gui.project import ProjectWindow
 from pyworkflow.viewer import (DESKTOP_TKINTER, WEB_DJANGO, Viewer)
 import pyworkflow.em as em
 import pyworkflow.em.showj as showj
+import pyworkflow.utils as pwutils
 from pyworkflow.em.plotter import EmPlotter
 from protocol_gctf import ProtGctf
 from convert import readCtfModel
+
+
+OBJCMD_GCTF = "Display Ctf Analysis"
 
 
 class ProtGctfViewer(Viewer):
@@ -41,7 +45,6 @@ class ProtGctfViewer(Viewer):
     _environments = [DESKTOP_TKINTER, WEB_DJANGO]
     _label = 'viewer Gctf'
     _targets = [ProtGctf]
-     
      
     def __init__(self, **args):
         Viewer.__init__(self, **args)
@@ -117,15 +120,15 @@ class ProtGctfViewer(Viewer):
                                                          showj.VISIBLE: labels,
                                                          showj.ZOOM: 50,
                                                          showj.RENDER: psdLabels,
-                                                         showj.OBJCMDS: "'%s'" % showj.OBJCMD_GCTF}))
+                                                         showj.OBJCMDS: "'%s'" % OBJCMD_GCTF}))
 
         return self._views
 
+
 def createCtfPlot(ctfSet, ctfId):
-    from pyworkflow.utils.path import removeExt
     ctfModel = ctfSet[ctfId]
     psdFn = ctfModel.getPsdFile()
-    fn = removeExt(psdFn) + "_EPA.txt"
+    fn = pwutils.removeExt(psdFn) + "_EPA.txt"
     gridsize = [1, 1]
     xplotter = EmPlotter(x=gridsize[0], y=gridsize[1], windowTitle='CTF Fitting')
     plot_title = "CTF Fitting"
@@ -140,10 +143,15 @@ def createCtfPlot(ctfSet, ctfId):
     a.grid(True)
     xplotter.show()
 
+
+ProjectWindow.registerObjectCommand(OBJCMD_GCTF, createCtfPlot)
+
+
 def _plotCurve(a, i, fn):
     freqs = _getValues(fn, 0)
     curv = _getValues(fn, i)
     a.plot(freqs, curv)
+
 
 def _getValues(fn, col):
     f = open(fn)

--- a/pyworkflow/em/packages/grigoriefflab/viewer.py
+++ b/pyworkflow/em/packages/grigoriefflab/viewer.py
@@ -28,12 +28,13 @@ Visualization of the results of the Frealign protocol.
 """
 import os
 from os.path import exists, relpath
-from pyworkflow.utils.path import cleanPath, removeBaseExt
+from pyworkflow.utils.path import cleanPath, removeBaseExt, removeExt
 from pyworkflow.viewer import (ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO, Viewer)
 from pyworkflow.em.viewer import CtfView, DataView
 import pyworkflow.em as em
 import pyworkflow.em.showj as showj
 
+from pyworkflow.gui.project import ProjectWindow
 from pyworkflow.em.plotter import EmPlotter
 from pyworkflow.protocol.constants import LEVEL_ADVANCED
 from pyworkflow.protocol.params import (LabelParam, NumericRangeParam,IntParam,
@@ -597,7 +598,6 @@ class ProtCTFFindViewer(Viewer):
         return ctfSet
     
 def createCtfPlot(ctfSet, ctfId):
-    from pyworkflow.utils.path import removeExt
     ctfModel = ctfSet[ctfId]
     psdFn = ctfModel.getPsdFile()
     fn = removeExt(psdFn) + "_avrot.txt"
@@ -616,6 +616,9 @@ def createCtfPlot(ctfSet, ctfId):
     xplotter.showLegend(legendName)
     a.grid(True)
     xplotter.show()
+
+OBJCMD_CTFFIND4 = "Display Ctf Fitting"
+ProjectWindow.registerObjectCommand(OBJCMD_CTFFIND4, createCtfPlot)
 
 def _plotCurve(a, i, fn):
     freqs = _getValues(fn, 0)

--- a/pyworkflow/em/packages/xmipp3/nma/viewer_nma.py
+++ b/pyworkflow/em/packages/xmipp3/nma/viewer_nma.py
@@ -28,6 +28,7 @@ This module implement the wrappers around Xmipp NMA protocol
 visualization program.
 """
 
+from pyworkflow.gui.project import ProjectWindow
 from pyworkflow.protocol.params import LabelParam, IntParam
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER, WEB_DJANGO
 from pyworkflow.em.viewer import ObjectView, VmdView
@@ -35,8 +36,10 @@ from protocol_nma import XmippProtNMA
 from plotter import XmippNmaPlotter
 import xmipp
 
+OBJCMD_NMA_PLOTDIST = "Plot distance profile"
+OBJCMD_NMA_VMD = "Display VMD animation"
 
-        
+
 class XmippNMAViewer(ProtocolViewer):
     """ Visualization of results from the NMA protocol.    
         Normally, NMA modes with high collectivity and low NMA score are preferred.
@@ -89,7 +92,9 @@ class XmippNMAViewer(ProtocolViewer):
         mode = modes[modeNumber]
         
         if mode is None:
-            return [self.errorMessage("Invalid mode number *%d*\nDisplay the output Normal Modes to see the availables ones." % modeNumber, 
+            return [self.errorMessage("Invalid mode number *%d*\n"
+                                      "Display the output Normal Modes to see "
+                                      "the availables ones." % modeNumber,
                                       title="Invalid input")]
         elif paramName == 'displayVmd':
             return [createVmdView(self.protocol, modeNumber)]
@@ -103,11 +108,31 @@ def createShiftPlot(mdFn, title, ylabel):
     plotter.plotMdFile(mdFn, None, xmipp.MDL_NMA_ATOMSHIFT)
     return plotter
 
+
 def createDistanceProfilePlot(protocol, modeNumber):
-    vectorMdFn = protocol._getExtraPath("distanceProfiles","vec%d.xmd" % modeNumber)
-    plotter = createShiftPlot(vectorMdFn, "Atom shifts for mode %d" % modeNumber, "shift")
+    vectorMdFn = protocol._getExtraPath("distanceProfiles","vec%d.xmd"
+                                        % modeNumber)
+    plotter = createShiftPlot(vectorMdFn, "Atom shifts for mode %d"
+                              % modeNumber, "shift")
     return plotter
 
+
 def createVmdView(protocol, modeNumber):
-    vmdFile = protocol._getExtraPath("animations", "animated_mode_%03d.vmd" % modeNumber)
+    vmdFile = protocol._getExtraPath("animations", "animated_mode_%03d.vmd"
+                                     % modeNumber)
     return VmdView('-e "%s"' % vmdFile)
+
+
+def showDistanceProfilePlot(protocol, modeNumber):
+    createDistanceProfilePlot(protocol, modeNumber).show()
+
+
+def showVmdView(protocol, modeNumber):
+    createVmdView(protocol, modeNumber).show()
+
+
+ProjectWindow.registerObjectCommand(OBJCMD_NMA_PLOTDIST,
+                                    showDistanceProfilePlot)
+ProjectWindow.registerObjectCommand(OBJCMD_NMA_VMD,
+                                    showVmdView)
+

--- a/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
@@ -34,11 +34,17 @@ import sys
 import numpy as np
 
 import pyworkflow.em as em
+from pyworkflow.gui.project import ProjectWindow
 from pyworkflow.em.protocol import ProtAlignMovies
 from pyworkflow.utils.path import moveFile
 import pyworkflow.protocol.params as params
 from pyworkflow.gui.plotter import Plotter
 from convert import writeShiftsMovieAlignment, getMovieFileName
+
+
+PLOT_CART = 0
+PLOT_POLAR = 1
+OBJCMD_MOVIE_ALIGNCARTESIAN = "Display Cartesian Presentation"
 
 
 class XmippProtOFAlignment(ProtAlignMovies):
@@ -234,11 +240,19 @@ class XmippProtOFAlignment(ProtAlignMovies):
         movieFolder = self._getOutputMovieFolder(movie)
         return join(movieFolder, self._getMovieRoot(movie) + '_shifts.xmd')
 
+
 def createPlots(plotType, protocol, micId):
     print "output Micrographs to create Plot %s" % protocol.outputMicrographs
     mic = protocol.outputMicrographs[micId]
     return movieCreatePlot(mic, False).show()
 
+
+def showCartesianShiftsPlot(protocol, movieId):
+    createPlots(PLOT_CART, protocol, movieId)
+
+
+ProjectWindow.registerObjectCommand(OBJCMD_MOVIE_ALIGNCARTESIAN,
+                                    showCartesianShiftsPlot)
 
 def movieCreatePlot(mic, saveFig):
     import pyworkflow.em.metadata as md

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -60,9 +60,14 @@ from protocol_rotational_spectra import XmippProtRotSpectra
 from protocol_screen_particles import XmippProtScreenParticles
 from protocol_ctf_micrographs import XmippProtCTFMicrographs
 from pyworkflow.em.showj import *
-from protocol_movie_opticalflow import XmippProtOFAlignment
+from protocol_movie_opticalflow import (XmippProtOFAlignment,
+                                        OBJCMD_MOVIE_ALIGNCARTESIAN)
 from protocol_validate_nontilt import XmippProtValidateNonTilt
 from protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
+
+
+
+
 
 class XmippViewer(Viewer):
     """ Wrapper to visualize different type of objects
@@ -128,7 +133,7 @@ class XmippViewer(Viewer):
 
         return ctfSet
 
-    def _visualize(self, obj, **args):
+    def _visualize(self, obj, **kwargs):
         cls = type(obj)
 
         if issubclass(cls, Volume):
@@ -144,10 +149,12 @@ class XmippViewer(Viewer):
             
         elif issubclass(cls, SetOfNormalModes):
             fn = obj.getFileName()
+            from nma.viewer_nma import OBJCMD_NMA_PLOTDIST, OBJCMD_NMA_VMD
             objCommands = "'%s' '%s'" % (OBJCMD_NMA_PLOTDIST, OBJCMD_NMA_VMD)
-            self._views.append(ObjectView(self._project,  self.protocol.strId(),
+            self._views.append(ObjectView(self._project, self.protocol.strId(),
                                           fn, obj.strId(),
-                                          viewParams={OBJCMDS: objCommands}, **args))
+                                          viewParams={OBJCMDS: objCommands},
+                                          **kwargs))
 
         elif issubclass(cls, SetOfMovies):
             fn = obj.getFileName()
@@ -160,7 +167,7 @@ class XmippViewer(Viewer):
 
         elif issubclass(cls, SetOfMicrographs):            
             fn = obj.getFileName()
-            self._views.append(ObjectView(self._project, obj.strId(), fn, **args))
+            self._views.append(ObjectView(self._project, obj.strId(), fn, **kwargs))
             
 
         elif issubclass(cls, MicrographsTiltPair):          
@@ -226,7 +233,7 @@ class XmippViewer(Viewer):
         
         elif issubclass(cls, SetOfClasses2D):
             fn = obj.getFileName()
-            self._views.append(ClassesView(self._project, obj.strId(), fn, **args))
+            self._views.append(ClassesView(self._project, obj.strId(), fn, **kwargs))
             
         elif issubclass(cls, SetOfClasses3D):
             fn = obj.getFileName()

--- a/pyworkflow/em/protocol/protocol_movies.py
+++ b/pyworkflow/em/protocol/protocol_movies.py
@@ -43,8 +43,6 @@ from pyworkflow.em import ImageHandler
 from protocol_micrographs import ProtPreprocessMicrographs
 from protocol_particles import ProtExtractParticles
 
-PLOT_CART = 0
-PLOT_POLAR = 1
 
 
 class ProtProcessMovies(ProtPreprocessMicrographs):

--- a/pyworkflow/em/showj.py
+++ b/pyworkflow/em/showj.py
@@ -69,13 +69,6 @@ CHIMERA_PORT = 'chimera_port'
 INVERTY = 'inverty'
 
 OBJCMDS = 'object_commands'
-OBJCMD_NMA_PLOTDIST = "Plot distance profile"
-OBJCMD_NMA_VMD = "Display VMD animation"
-#OBJCMD_MOVIE_ALIGNPOLAR = "Display Polar Presentation"
-OBJCMD_MOVIE_ALIGNCARTESIAN = "Display Cartesian Presentation"
-#OBJCMD_MOVIE_ALIGNPOLARCARTESIAN = "Display Polar + Cartesian Presentations"
-OBJCMD_CTFFIND4 = "Display Ctf Fitting"
-OBJCMD_GCTF = "Display Ctf Analysis"
 
 GOTO = 'goto'
 ROWS = 'rows'

--- a/pyworkflow/em/viewer.py
+++ b/pyworkflow/em/viewer.py
@@ -190,7 +190,8 @@ class CtfView(ObjectView):
             viewParams['dont_recalc_ctf'] = ''
 
         if first.hasAttribute('_ctffind4_ctfResolution'):
-            viewParams[showj.OBJCMDS] = "'%s'" % showj.OBJCMD_CTFFIND4
+            import pyworkflow.em.packages.grigoriefflab.viewer as gviewer
+            viewParams[showj.OBJCMDS] = "'%s'" % gviewer.OBJCMD_CTFFIND4
 
         inputId = ctfSet.getObjId() or ctfSet.getFileName()
         ObjectView.__init__(self, project,

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -53,15 +53,14 @@ from pyworkflow.gui.text import _open_cmd, openTextFileEditor
 from labels import LabelsDialog
 
 # Import possible Object commands to be handled
-from pyworkflow.em.showj import (OBJCMD_NMA_PLOTDIST, OBJCMD_NMA_VMD,
-                                 OBJCMD_MOVIE_ALIGNCARTESIAN, OBJCMD_CTFFIND4,
-                                 OBJCMD_GCTF)
 from base import ProjectBaseWindow, VIEW_PROTOCOLS, VIEW_PROJECTS
 
 
 
 class ProjectWindow(ProjectBaseWindow):
     """ Main window for working in a Project. """
+    _OBJECT_COMMANDS = {}
+
     def __init__(self, path, master=None):
         # Load global configuration
         self.projName = Message.LABEL_PROJECT + os.path.basename(path)
@@ -246,38 +245,30 @@ class ProjectWindow(ProjectBaseWindow):
     def schedulePlot(self, path, *args):
         self.enqueue(lambda: plotFile(path, *args).show())    
 
+    @classmethod
+    def registerObjectCommand(cls, cmd, func):
+        """ Register an object command to be handled when receiving the
+        action from showj. """
+        cls._OBJECT_COMMANDS[cmd] = func
+
     def runObjectCommand(self, cmd, inputStrId, objStrId):
         try:
-            from pyworkflow.em.packages.xmipp3.nma.viewer_nma import createDistanceProfilePlot
-            from pyworkflow.em.packages.xmipp3.protocol_movie_opticalflow import createPlots
-            from pyworkflow.em.protocol.protocol_movies import PLOT_CART
-            from pyworkflow.em.packages.xmipp3.nma.viewer_nma import createVmdView
             objId = int(objStrId)
             project = self.project
+
             if os.path.isfile(inputStrId) and os.path.exists(inputStrId):
                 from pyworkflow.em import loadSetFromDb
                 inputObj = loadSetFromDb(inputStrId)
             else:
                 inputId = int(inputStrId)
                 inputObj = project.mapper.selectById(inputId)
-            #Plotter.setBackend('TkAgg')
-            if cmd == OBJCMD_NMA_PLOTDIST:
-                self.enqueue(lambda: createDistanceProfilePlot(inputObj, modeNumber=objId).show())
-    
-            elif cmd == OBJCMD_NMA_VMD:
-                vmd = createVmdView(inputObj, modeNumber=objId)
-                vmd.show()
 
-            elif cmd == OBJCMD_MOVIE_ALIGNCARTESIAN:
-                self.enqueue(lambda: createPlots(PLOT_CART, inputObj, objId))
+            func = self._OBJECT_COMMANDS.get(cmd, None)
 
-            elif cmd == OBJCMD_CTFFIND4:
-                from pyworkflow.em.packages.grigoriefflab.viewer import createCtfPlot
-                self.enqueue(lambda: createCtfPlot(inputObj, objId))
-
-            elif cmd == OBJCMD_GCTF:
-                from pyworkflow.em.packages.gctf.viewer import createCtfPlot
-                self.enqueue(lambda: createCtfPlot(inputObj, objId))
+            if func is None:
+                print "Error, command '%s' not found. "
+            else:
+                self.enqueue(lambda: func(inputObj, objId))
 
         except Exception, ex:
             print "There was an error executing object command !!!:"

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -268,7 +268,10 @@ class ProjectWindow(ProjectBaseWindow):
             if func is None:
                 print "Error, command '%s' not found. "
             else:
-                self.enqueue(lambda: func(inputObj, objId))
+                def myfunc():
+                    func(inputObj, objId)
+                    inputObj.close()
+                self.enqueue(myfunc)
 
         except Exception, ex:
             print "There was an error executing object command !!!:"

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -266,7 +266,7 @@ class ProjectWindow(ProjectBaseWindow):
             func = self._OBJECT_COMMANDS.get(cmd, None)
 
             if func is None:
-                print "Error, command '%s' not found. "
+                print "Error, command '%s' not found. " % cmd
             else:
                 def myfunc():
                     func(inputObj, objId)


### PR DESCRIPTION
Object-Commands are commands passed to Showj Java app when visualizing some to dynamically add command available for specific items. Then Showj call back the project gui that is listening at some port and react to this commands. 

Before, the gui/project.py contains the dirty includes for the commands. Now it has a **registerCommand** method to register new command without changing the code at this levels.

After this, I added 3 extra commands to improve Eman2 initial-volume visualization as suggested by @azazellochg  in #546 

@azazellochg , could you double check that everything is working as expected?