### PR TITLE
Adding labels to scipion script to filter tests

### DIFF
--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -14,7 +14,7 @@ from pyworkflow.em.convert import ImageHandler
 
 class TestFSC(unittest.TestCase):
     
-    _labels = [WEEKLY]
+    _labels = [SMALL, WEEKLY]
         
     def testIO(self):
         """Test basic FSC object"""
@@ -46,8 +46,8 @@ class TestFSC(unittest.TestCase):
 
 
 class TestImage(unittest.TestCase):
-    
-    _labels = [WEEKLY]
+
+    _labels = [SMALL, WEEKLY]
 
     @classmethod
     def setUpClass(cls):
@@ -76,8 +76,8 @@ class TestImage(unittest.TestCase):
 
 
 class TestImageHandler(unittest.TestCase):
-    
-    _labels = [WEEKLY]
+
+    _labels = [SMALL, WEEKLY]
     
     @classmethod
     def setUpClass(cls):
@@ -173,7 +173,9 @@ class TestImageHandler(unittest.TestCase):
 
 
 class TestSetOfMicrographs(BaseTest):
-    
+
+    _labels = [SMALL, WEEKLY]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -261,8 +263,11 @@ class TestSetOfMicrographs(BaseTest):
 
 
 class TestSetOfParticles(BaseTest):
-    """ Check if the information of the images is copied to another image when a new SetOfParticles is created"""
-    
+    """ Check if the information of the images is copied to another image when
+    a new SetOfParticles is created"""
+
+    _labels = [SMALL, WEEKLY]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -407,7 +412,9 @@ class TestSetOfParticles(BaseTest):
 
 
 class TestSetOfClasses2D(BaseTest):
-    
+
+    _labels = [SMALL, WEEKLY]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -428,8 +435,11 @@ class TestSetOfClasses2D(BaseTest):
         img1 = cls1.getFirstItem()
         self.assertEqual(img1.getObjId(), 1) # First image of first class is 1 in this test
         
-        images = [[1, 3, 4, 5, 7, 9, 11, 14, 16, 17, 21, 22, 24, 26, 28, 29, 30, 35, 37, 38, 39, 40, 42, 45, 54, 57, 62, 65, 67, 69, 70, 71, 74], 
-                  [2, 8, 10, 12, 13, 15, 19, 20, 23, 25, 27, 33, 34, 41, 43, 44, 46, 47, 48, 49, 50, 51, 52, 53, 55, 56, 58, 59, 60, 61, 63, 64, 68, 72, 73, 75, 76], 
+        images = [[1, 3, 4, 5, 7, 9, 11, 14, 16, 17, 21, 22, 24, 26, 28, 29, 30,
+                   35, 37, 38, 39, 40, 42, 45, 54, 57, 62, 65, 67, 69, 70, 71, 74],
+                  [2, 8, 10, 12, 13, 15, 19, 20, 23, 25, 27, 33, 34, 41, 43, 44,
+                   46, 47, 48, 49, 50, 51, 52, 53, 55, 56, 58, 59, 60, 61, 63,
+                   64, 68, 72, 73, 75, 76],
                   [18, 31, 32], 
                   [6, 36, 66]]
         
@@ -525,7 +535,9 @@ class TestTransform(BaseTest):
         
     
 class TestCopyItems(BaseTest):
-    
+
+    _labels = [SMALL, WEEKLY]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -569,14 +581,8 @@ class TestCopyItems(BaseTest):
         for i1, i2 in izip(inputSet, checkSet):
             self.assertTrue(i2.equalAttributes(i1, ignore=['_list']))
         
-        
     def _updateItem(self, item, row):
         item._list = CsvList()
         item._list.set([1.0, 2.0])
 
 
-if __name__ == '__main__':
-#    suite = unittest.TestLoader().loadTestsFromName('test_data_xmipp.TestXmippCTFModel.testConvertXmippCtf')
-#    unittest.TextTestRunner(verbosity=2).run(suite)
-    
-    unittest.main()

--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -13,6 +13,8 @@ from pyworkflow.em.convert import ImageHandler
 
 
 class TestFSC(unittest.TestCase):
+    
+    _labels = [WEEKLY]
         
     def testIO(self):
         """Test basic FSC object"""
@@ -44,6 +46,8 @@ class TestFSC(unittest.TestCase):
 
 
 class TestImage(unittest.TestCase):
+    
+    _labels = [WEEKLY]
 
     @classmethod
     def setUpClass(cls):
@@ -72,6 +76,9 @@ class TestImage(unittest.TestCase):
 
 
 class TestImageHandler(unittest.TestCase):
+    
+    _labels = [WEEKLY]
+    
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)

--- a/pyworkflow/tests/em/data/test_metadata.py
+++ b/pyworkflow/tests/em/data/test_metadata.py
@@ -31,6 +31,8 @@ import pyworkflow.em.metadata as md
 
 
 class TestMetaData(unittest.TestCase):
+    
+    _labels = [WEEKLY]
 
     def _newMd(self):
         md0 = md.MetaData()

--- a/pyworkflow/tests/em/programs/base.py
+++ b/pyworkflow/tests/em/programs/base.py
@@ -29,6 +29,7 @@ import unittest
 import threading
 import subprocess
 
+from pyworkflow.tests import *
 import pyworkflow.utils as pwutils
 
 import xmipp
@@ -66,6 +67,8 @@ class ProgramTest(unittest.TestCase):
     _testDir = None
     _environ = None
     _timeout = 300
+    
+    _labels = [WEEKLY]
                
     @classmethod
     def setTestDir(cls, newTestDir):

--- a/pyworkflow/tests/em/programs/test_pythoninferface_xmipp.py
+++ b/pyworkflow/tests/em/programs/test_pythoninferface_xmipp.py
@@ -10,6 +10,7 @@ import unittest
 from tempfile import NamedTemporaryFile
 from time import time
 
+from pyworkflow.tests import *
 from xmipp import *
 from pyworkflow.em.packages.xmipp3 import getXmippPath
 import pyworkflow.utils as pwutils
@@ -40,6 +41,9 @@ def binaryFileComparison(nameo, namet):
 
 
 class TestXmippPythonInterface(unittest.TestCase):
+    
+    _labels = [WEEKLY]
+    
     testsPath = getXmippPath("resources", "test")
     # Temporary filenames used
 

--- a/pyworkflow/tests/em/workflows/test_workflow_existing.py
+++ b/pyworkflow/tests/em/workflows/test_workflow_existing.py
@@ -12,6 +12,8 @@ from pyworkflow.mapper.sqlite import SqliteFlatMapper
     
 class TestXmippWorkflow(unittest.TestCase):
     
+    _labels = [WEEKLY]
+    
     def loadProject(self, projName):
         """ Try to load an existing project. """
         manager = Manager()

--- a/pyworkflow/tests/model/test_canvas.py
+++ b/pyworkflow/tests/model/test_canvas.py
@@ -9,10 +9,13 @@ import Tkinter
 import math
 from pyworkflow.tests import *
 
+
 class TestCanvas(BaseTest):
     # IMPORTANT: Tk requires at least that DISPLAY is defined
     # hence in some environments (like buildbot) the test may fail,
     # check for the TclError exception
+    
+    _labels = [PULL_REQUEST] 
     
     @classmethod
     def setUpClass(cls):

--- a/pyworkflow/tests/model/test_mappers.py
+++ b/pyworkflow/tests/model/test_mappers.py
@@ -42,7 +42,8 @@ from pyworkflow.mapper.sqlite_db import SqliteDb
 
 
 class TestSqliteMapper(BaseTest):
-    
+    _labels = [SMALL]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -269,6 +270,7 @@ class TestSqliteMapper(BaseTest):
         
 class TestSqliteFlatMapper(BaseTest):
     """ Some tests for DataSet implementation. """
+    _labels = [SMALL]
 
     @classmethod
     def setUpClass(cls):
@@ -379,6 +381,7 @@ class TestXmlMapper(BaseTest):
 
 class TestDataSet(BaseTest):
     """ Some tests for DataSet implementation. """
+    _labels = [SMALL]
 
     @classmethod
     def setUpClass(cls):

--- a/pyworkflow/tests/model/test_object.py
+++ b/pyworkflow/tests/model/test_object.py
@@ -13,7 +13,8 @@ class ListContainer(Object):
     
     
 class TestObject(BaseTest):
-    
+    _labels = [SMALL]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
@@ -303,7 +304,8 @@ class TestObject(BaseTest):
         
 
 class TestUtils(BaseTest):
-    
+    _labels = [SMALL]
+
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)

--- a/pyworkflow/tests/tests.py
+++ b/pyworkflow/tests/tests.py
@@ -17,29 +17,21 @@ TESTS_INPUT = join(os.environ['SCIPION_HOME'], 'data', 'tests')
 TESTS_OUTPUT = join(os.environ['SCIPION_USER_DATA'], 'Tests')
 
 
+SMALL = 'small'
 PULL_REQUEST = 'pull'
 DAILY = 'daily'
 WEEKLY = 'weekly'
 
+
 # Procedure to check if a test class has an attribute called _labels and if so
 # then it checks if the class test matches any of the labels in input label parameter.
-def hasLabel(TestClass, label):
+def hasLabel(TestClass, labels):
     
     # Get _labels attributes in class if any.
     classLabels = getattr(TestClass, '_labels', None)
 
     # Check if no label in test class.    
-    if classLabels is None:
-        labelExists = False
-    else:
-        # Check if any of the class labels matches.
-        for i in classLabels:
-            for j in label:
-                if (i == j):
-                    labelExists = True
-                else:
-                    labelExists = False
-    return labelExists
+    return classLabels is not None and any(l in classLabels for l in labels)
 
 
 class DataSet:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -187,52 +187,37 @@ class Tester():
             if moduleName.startswith('unittest.loader.ModuleImportFailure'):
                 print pwutils.red(moduleName), "  test:", t.id()
                 continue
-      
-            if (self.labels is not None):
-                
-                # Get class and create a new instance.
+
+            def _hasLabels():
+                if self.labels is None:
+                    return True
+
+                # Check if class has a label that matches input labels.
                 import importlib
                 my_module = importlib.import_module(moduleName)
                 MyClass = getattr(my_module, className)
 
-                # Check if class has a label that matches input labels.
-                if (pwtests.hasLabel(MyClass, self.labels)):
-                
-                    if moduleName != lastModule:
-                        lastModule = moduleName
-                        newItemCallback(MODULE, moduleName)
-                        #print "scipion test %s" % moduleName
-                        
-                    if mode in ['classes', 'all'] and className != lastClass:
-                        lastClass = className
-                        newItemCallback(CLASS, "%s.%s" % (moduleName, className))
-                        #print "  scipion test %s.%s" % (moduleName, className)
-                        
-                    if mode == 'all':
-                        newItemCallback(TEST, "%s.%s.%s" % (moduleName, className, testName))
-                        #print "    scipion test %s.%s.%s" % (moduleName, className, testName)
-            else:
-                
+                return pwtests.hasLabel(MyClass, self.labels)
+
+            if _hasLabels():
+
                 if moduleName != lastModule:
                     lastModule = moduleName
                     newItemCallback(MODULE, moduleName)
-                    #print "scipion test %s" % moduleName
-                        
+
                 if mode in ['classes', 'all'] and className != lastClass:
                     lastClass = className
                     newItemCallback(CLASS, "%s.%s" % (moduleName, className))
-                    #print "  scipion test %s.%s" % (moduleName, className)
-                        
+
                 if mode == 'all':
                     newItemCallback(TEST, "%s.%s.%s" % (moduleName, className, testName))
-                    #print "    scipion test %s.%s.%s" % (moduleName, className, testName)
 
         # If label is "pull" then add all basic xmipp tests.
         if (self.labels is not None):
             if PULL_REQUEST in self.labels:
-                self.discoverXmippTest( newItemCallback)
+                self.discoverXmippTest(newItemCallback)
         else:
-            self.discoverXmippTest( newItemCallback)
+            self.discoverXmippTest(newItemCallback)
     
     def _printNewItem(self, itemType, itemName):
         if self._match(itemName):

--- a/software/em/xmipp/applications/tests/test_emx/batch_test_emx.py
+++ b/software/em/xmipp/applications/tests/test_emx/batch_test_emx.py
@@ -54,6 +54,9 @@ except ImportError:
     sys.stderr.write('Could not import OrderedDict, test not available')
 
 class TestEMX(unittest.TestCase):
+    
+    _labels = [WEEKLY]
+    
     testsPath = getXmippPath("resources", "test")
     def setUp(self):
         """This function performs all the setup stuff.      

--- a/software/em/xmipp/applications/tests/test_pysqlite/batch_test_pysqlite.py
+++ b/software/em/xmipp/applications/tests/test_pysqlite/batch_test_pysqlite.py
@@ -58,6 +58,9 @@ _sqlCommand4 = "CREATE TABLE verifyfiles "\
                "FOREIGN KEY(step_id, run_id) REFERENCES steps(step_id, run_id) on delete cascade);" 
 
 class TestPySqlite(unittest.TestCase):
+    
+    _labels = [WEEKLY]
+    
     testsPath = os.path.split(os.path.dirname(os.popen('which xmipp_protocols', 'r').read()))[0] + '/applications/tests'
     def setUp(self):
         """This function performs all the setup stuff.      


### PR DESCRIPTION
The scipion script has been modified to accept a new parameter "--label" that filters the test to be listed by "--show" or executed by "--run". This new label parameter accepts a list of labels and filters the test that match the set of labels.

Currently the test accept three label values: pull, daily and weekly. It defines the execution of the test in buildbot: pull when it must be executed under a new pull request, daily to be executed once a day and weekly to be executed during the weekend. 

At this moment, only one TestCanvas is defined as pull request, and all the others are set to weekly.