### PR TITLE
Updating metadata interface and including tests

### DIFF
--- a/software/em/xmipp/applications/tests/test_metadata/test_metadata_main.cpp
+++ b/software/em/xmipp/applications/tests/test_metadata/test_metadata_main.cpp
@@ -7,6 +7,41 @@
 #include <gtest/gtest.h>
 #include <string.h>
 #include <fstream>
+#include <sys/time.h>
+
+#define N_ROWS_TEST		2
+#define N_ROWS_PERFORMANCE_TEST		800
+
+struct timeval getTime()
+{
+    struct timeval time;
+    gettimeofday(&time, 0);
+
+    return(time);
+}
+
+void timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y)
+{
+  // Perform the carry for the later subtraction by updating y.
+  if (x->tv_usec < y->tv_usec)
+  {
+	  int nsec = (y->tv_usec - x->tv_usec) / 1000000 + 1;
+	  y->tv_usec -= 1000000 * nsec;
+	  y->tv_sec += nsec;
+  }
+  if (x->tv_usec - y->tv_usec > 1000000)
+  {
+	  int nsec = (x->tv_usec - y->tv_usec) / 1000000;
+	  y->tv_usec += 1000000 * nsec;
+	  y->tv_sec -= nsec;
+  }
+
+  // Compute the time remaining to wait. tv_usec is certainly positive.
+  result->tv_sec = x->tv_sec - y->tv_sec;
+  result->tv_usec = x->tv_usec - y->tv_usec;
+}
+
+
 /*
  * Define a "Fixture so we may reuse the metadatas
  */
@@ -130,40 +165,6 @@ TEST_F( MetadataTest, AddRow)
 
     EXPECT_EQ(md, mDsource);
     EXPECT_EQ(md2, mDsource);
-}
-
-#include <sys/time.h>
-
-#define N_ROWS_TEST		2
-#define N_ROWS_PERFORMANCE_TEST		800
-
-struct timeval getTime()
-{
-    struct timeval time;
-    gettimeofday(&time, 0);
-
-    return(time);
-}
-
-void timeval_subtract (struct timeval *result, struct timeval *x, struct timeval *y)
-{
-  // Perform the carry for the later subtraction by updating y.
-  if (x->tv_usec < y->tv_usec)
-  {
-	  int nsec = (y->tv_usec - x->tv_usec) / 1000000 + 1;
-	  y->tv_usec -= 1000000 * nsec;
-	  y->tv_sec += nsec;
-  }
-  if (x->tv_usec - y->tv_usec > 1000000)
-  {
-	  int nsec = (x->tv_usec - y->tv_usec) / 1000000;
-	  y->tv_usec += 1000000 * nsec;
-	  y->tv_sec -= nsec;
-  }
-
-  // Compute the time remaining to wait. tv_usec is certainly positive.
-  result->tv_sec = x->tv_sec - y->tv_sec;
-  result->tv_usec = x->tv_usec - y->tv_usec;
 }
 
 TEST_F( MetadataTest, AddRows)

--- a/software/em/xmipp/libraries/data/metadata.cpp
+++ b/software/em/xmipp/libraries/data/metadata.cpp
@@ -272,7 +272,7 @@ bool MetaData::initGetRow( bool addWhereClause) const
     return(success);
 }
 
-bool MetaData::execGetRow(MDRow &row)
+bool MetaData::execGetRow(MDRow &row) const
 {
 	bool success=true;
 	std::vector<MDObject> mdValues;		// Vector to store values.
@@ -299,7 +299,7 @@ bool MetaData::execGetRow(MDRow &row)
     return(success);
 }
 
-void 	MetaData::finalizeGetRow(void)
+void 	MetaData::finalizeGetRow(void) const
 {
 	myMDSql->finalizePreparedStmt();
 }
@@ -317,7 +317,7 @@ bool MetaData::getRow(MDRow &row, size_t id) const
     return true;
 }
 
-bool MetaData::getRow2(MDRow &row, size_t id)
+bool MetaData::getRow2(MDRow &row, size_t id) const
 {
 	bool success=true;
 
@@ -334,7 +334,7 @@ bool MetaData::getRow2(MDRow &row, size_t id)
 		success = execGetRow( row);
 
 	    // Finalize SELECT.
-	    myMDSql->finalizePreparedStmt();
+		finalizeGetRow();
 	}
 
 	return(success);
@@ -414,10 +414,17 @@ bool MetaData::execSetRow(const MDRow &row, size_t id)
 	return(success);
 }
 
+void 	MetaData::finalizeSetRow(void)
+{
+	myMDSql->finalizePreparedStmt();
+}
 
-void MetaData::setRow(const MDRow &row, size_t id)
+
+bool MetaData::setRow(const MDRow &row, size_t id)
 {
     SET_ROW_VALUES(row);
+
+    return(true);
 }
 
 bool MetaData::setRow2(const MDRow &row, size_t id)
@@ -432,7 +439,7 @@ bool MetaData::setRow2(const MDRow &row, size_t id)
 		success = execSetRow( row, id);
 
 		// Finalize UPDATE.
-		myMDSql->finalizePreparedStmt();
+		finalizeSetRow();
 	}
 
 	return(success);
@@ -509,6 +516,11 @@ bool MetaData::execAddRow(const MDRow &row)
     return(success);
 }
 
+void 	MetaData::finalizeAddRow(void)
+{
+	myMDSql->finalizePreparedStmt();
+}
+
 size_t MetaData::addRow(const MDRow &row)
 {
     size_t id = addObject();
@@ -518,22 +530,29 @@ size_t MetaData::addRow(const MDRow &row)
 }
 
 
-bool MetaData::addRow2(const MDRow &row)
+size_t MetaData::addRow2(const MDRow &row)
 {
-	bool	success=true;				// Return value.
+	size_t id;		// Inserted row id.
 
 	// Initialize INSERT.
-	success = initAddRow( row);
-	if (success)
+	if (initAddRow( row))
 	{
 		// Execute INSERT.
-		success = execAddRow( row);
+		if (execAddRow( row))
+		{
+			// Get last inserted row id.
+			id = myMDSql->getObjId();
+		}
+		else
+		{
+			id = BAD_OBJID;
+		}
 
 		// Finalize INSERT.
-		myMDSql->finalizePreparedStmt();
+		finalizeAddRow();
 	}
 
-	return(success);
+	return(id);
 }
 
 MetaData::MetaData()

--- a/software/em/xmipp/libraries/data/metadata.h
+++ b/software/em/xmipp/libraries/data/metadata.h
@@ -644,22 +644,24 @@ public:
     bool	bindValue( size_t id) const;
 
     bool 	initGetRow(bool addWhereClause) const;
-    bool 	execGetRow(MDRow &row);
-    void 	finalizeGetRow(void);
+    bool 	execGetRow(MDRow &row) const;
+    void 	finalizeGetRow(void) const;
     bool 	getRow(MDRow &row, size_t id) const;
-    bool 	getRow2(MDRow &row, size_t id);
+    bool 	getRow2(MDRow &row, size_t id) const;
 
     /** Copy all the values in the input row in the current metadata*/
     bool 	initSetRow(const MDRow &row);
     bool 	execSetRow(const MDRow &row, size_t id);
-    void 	setRow(const MDRow &row, size_t id);
+    void 	finalizeSetRow(void);
+    bool 	setRow(const MDRow &row, size_t id);
     bool 	setRow2(const MDRow &row, size_t id);
 
     /** Add a new Row and set values, return the objId of newly added object */
     bool 	initAddRow(const MDRow &row);
     bool 	execAddRow(const MDRow &row);
+    void 	finalizeAddRow(void);
     size_t 	addRow(const MDRow &row);
-    bool  	addRow2(const MDRow &row);
+    size_t 	addRow2(const MDRow &row);
 
     /** Set label values from string representation.
      */

--- a/software/em/xmipp/libraries/data/metadata_sql.cpp
+++ b/software/em/xmipp/libraries/data/metadata_sql.cpp
@@ -148,6 +148,16 @@ bool MDSql::clearMd()
     return result;
 }
 
+size_t MDSql::getObjId()
+{
+	size_t id;		// Return value.
+
+	// Get last inserted row id.
+	id = sqlite3_last_insert_rowid(db);
+
+	return(id);
+}
+
 size_t MDSql::addRow()
 {
     //Fixme: this can be done in the constructor of MDCache only once

--- a/software/em/xmipp/libraries/data/metadata_sql.h
+++ b/software/em/xmipp/libraries/data/metadata_sql.h
@@ -136,6 +136,8 @@ private:
      */
     bool clearMd();
 
+    size_t getObjId();
+
     /**Add a new row and return the objId(rowId).
      */
     size_t addRow();

--- a/software/em/xmipp/libraries/data/xmipp_funcs.cpp
+++ b/software/em/xmipp/libraries/data/xmipp_funcs.cpp
@@ -698,18 +698,26 @@ size_t Timer::now()
            tv.tv_usec / 1000;
 }
 
-void Timer::tic()
+size_t Timer::tic()
 {
     tic_time = now();
+    return tic_time;
 }
 
-void Timer::toc(const char * msg)
+size_t Timer::toc(const char * msg, bool inSecs)
 {
     size_t diff = now() - tic_time;
+
     if (msg != NULL)
         std::cout << msg;
     std::cout << "Elapsed time: ";
-    std::cout << diff/1000.0 << " secs." << std::endl;
+
+    if (inSecs)
+        std::cout << diff/1000.0 << " secs." << std::endl;
+    else
+        std::cout << diff << " msecs." << std::endl;
+
+    return diff;
 }
 
 

--- a/software/em/xmipp/libraries/data/xmipp_funcs.h
+++ b/software/em/xmipp/libraries/data/xmipp_funcs.h
@@ -968,8 +968,8 @@ private:
 
 public:
   size_t now();
-  void tic();
-  void toc(const char * msg=NULL);
+  size_t tic();
+  size_t toc(const char * msg=NULL, bool inSecs=true);
 };
 
 #if !defined _NO_TIME && !defined __MINGW32__


### PR DESCRIPTION
There are a couple of functions, "getTime" and "timeval_subtract", in the "test_metadata_main.cpp" file that could be moved to another file as they are used to measure time executions. 

The addRow2, setRow2 and getRow2 are the new implemented functions and have been removed to use the old ones as they are the reference functions. Those three functions have been also added to some test to check that their behavior is the same as the reference functions.