### PR TITLE
Join different attrs

### DIFF
--- a/pyworkflow/em/protocol/protocol_sets.py
+++ b/pyworkflow/em/protocol/protocol_sets.py
@@ -100,6 +100,17 @@ class ProtUnionSet(ProtSets):
                       label="Create new ids",
                       help='Make an automatic renumbering of the ids, so the new objects\n'
                            'are not associated to the old ones.')
+
+        form.addParam('ignoreExtraAttributes', pwprot.params.BooleanParam,
+                      default=False, expertLevel=pwprot.LEVEL_ADVANCED,
+                      label='Ignore extra attributes?',
+                      help='By default, it is only allowed to join sets where'
+                           'each item has the same number of attributes. Set '
+                           'this option to *Yes* if you want to join sets with'
+                           'different attribues. The items in the resulting '
+                           'set will only the common attributes to all input '
+                           'sets. ')
+
         form.addParam('ignoreDuplicates', pwprot.params.BooleanParam, default=False,
                       expertLevel=pwprot.LEVEL_ADVANCED,
                       label='Ignore duplicates?',
@@ -131,11 +142,20 @@ class ProtUnionSet(ProtSets):
         # or we find duplicated ids in the sets
         cleanIds = self.renumber.get() or self.duplicatedIds()
 
+        if self.ignoreExtraAttributes:
+            commonAttrs = list(self.commonAttributes())
+
         for itemSet in self.inputSets:
             for obj in itemSet.get():
+                if self.ignoreExtraAttributes:
+                    newObj = itemSet.get().ITEM_TYPE()
+                    newObj.copyAttributes(obj, *commonAttrs)
+                else:
+                    newObj = obj
+
                 if cleanIds:
-                    obj.cleanObjId()
-                outputSet.append(obj)
+                    newObj.cleanObjId()
+                outputSet.append(newObj)
 
         self._defineOutputs(outputSet=outputSet)
         for itemSet in self.inputSets:
@@ -156,6 +176,23 @@ class ProtUnionSet(ProtSets):
                 usedIds.add(objId)
         return False
 
+    def commonAttributes(self):
+        """ Compute the set of common attributes to all items withint
+        each input set. """
+        commonAttrs = None
+
+        for itemSet in self.inputSets:
+            obj = itemSet.get().getFirstItem()
+            attrSet = {a for a, _ in obj.getAttributesToStore()}
+
+            if commonAttrs is None: # first time
+                commonAttrs = attrSet
+            else:
+                commonAttrs = commonAttrs & attrSet
+
+        return commonAttrs
+
+
     #--------------------------- INFO functions --------------------------------------------
     def _validate(self):
         # Are all inputSets from the same class?
@@ -164,13 +201,14 @@ class ProtUnionSet(ProtSets):
             return ["All objects should have the same type.",
                     "Types of objects found: %s" % ", ".join(classes)]
 
-        # Do all inputSets contain elements with the same attributes defined?
-        def attrNames(s):  # get attribute names of the first element of set s
-            return sorted(iter(s.get()).next().getObjDict().keys())
-        attrs = {tuple(attrNames(s)) for s in self.inputSets}  # tuples are hashable
-        if len(attrs) > 1:
-            return ["All elements must have the same attributes.",
-                    "Attributes found: %s" % ", ".join(str(x) for x in attrs)]
+        if not self.ignoreExtraAttributes:
+            # Do all inputSets contain elements with the same attributes defined?
+            def attrNames(s):  # get attribute names of the first element of set s
+                return sorted(iter(s.get()).next().getObjDict().keys())
+            attrs = {tuple(attrNames(s)) for s in self.inputSets}  # tuples are hashable
+            if len(attrs) > 1:
+                return ["All elements must have the same attributes.",
+                        "Attributes found: %s" % ", ".join(str(x) for x in attrs)]
 
         return []  # no errors
 

--- a/pyworkflow/object.py
+++ b/pyworkflow/object.py
@@ -304,10 +304,12 @@ class Object(object):
         There are two patchs for Pointer and PointerList.
         """
         for name in attrNames:
-            attr = getattr(self, name)
+            attr = getattr(self, name, None)
             otherAttr = getattr(other, name)
-            
-            if isinstance(attr, Pointer):
+
+            if attr is None:
+                setattr(self, name, otherAttr.clone())
+            elif isinstance(attr, Pointer):
                 attr.copy(otherAttr)
             elif isinstance(attr, PointerList):
                 for pointer in otherAttr:

--- a/pyworkflow/tests/em/protocols/test_protocols_sets.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_sets.py
@@ -242,6 +242,26 @@ class TestSets(BaseTest):
         check(self.movies)
         check(self.particles)
 
+    def testMergeDifferentAttrs(self):
+        """ Test merge from subsets with different attritubes. """
+        partFn = self.dataset_mda.getFile('particles/xmipp_particles.xmd')
+        protImport = self.newProtocol(ProtImportParticles,
+                                      objLabel='import from xmd',
+                                      importFrom=ProtImportParticles.IMPORT_FROM_XMIPP3,
+                                      mdFile=partFn,
+                                      samplingRate=3.5)
+
+        self.launchProtocol(protImport)
+        protJoin = self.newProtocol(ProtUnionSet,
+                                    objLabel='join different',
+                                    ignoreExtraAttributes=True)
+
+        protJoin.inputSets.append(self.particles)
+        protJoin.inputSets.append(protImport.outputParticles)
+
+        self.launchProtocol(protJoin)
+
+
     def testOrderBy(self):
         """ create set of particles and orderby a given attribute
         """

--- a/pyworkflow/tests/model/test_object.py
+++ b/pyworkflow/tests/model/test_object.py
@@ -181,7 +181,15 @@ class TestObject(BaseTest):
         c2.copyAttributes(c1, 'imag', 'real')
         
         self.assertTrue(c1.equalAttributes(c2), 
-                        'Complex c1 and c2 have not equal attributes\nc1: %s\nc2: %s\n' % (c1, c2))
+                        'Complex c1 and c2 have not equal attributes'
+                        '\nc1: %s\nc2: %s\n' % (c1, c2))
+
+        c1.score = Float(1.)
+
+        # If we copyAttributes again, score dynamic attribute should
+        # be set in c2
+        c2.copyAttributes(c1, 'score')
+        self.assertTrue(hasattr(c2, 'score'))
         
     def test_equalAttributes(self):
         """ Check that equal attributes function behaves well


### PR DESCRIPTION
Allow to do the join-set on sets which items could have different attributes. Only the common attributes are preserved in the output set. 