### PR TITLE
Rm fix addnoise

### DIFF
--- a/pyworkflow/em/packages/xmipp3/__init__.py
+++ b/pyworkflow/em/packages/xmipp3/__init__.py
@@ -64,7 +64,6 @@ from plotter import XmippPlotter
 
 from protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
 from protocol_align_volume import XmippProtAlignVolume, XmippProtAlignVolumeForWeb
-##ROB
 from pyworkflow.em.packages.xmipp3.protocol_preprocess.protocol_add_noise import XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles
 from protocol_apply_alignment import XmippProtApplyAlignment
 from protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix

--- a/pyworkflow/em/packages/xmipp3/__init__.py
+++ b/pyworkflow/em/packages/xmipp3/__init__.py
@@ -64,7 +64,8 @@ from plotter import XmippPlotter
 
 from protocol_assignment_tilt_pair import XmippProtAssignmentTiltPair
 from protocol_align_volume import XmippProtAlignVolume, XmippProtAlignVolumeForWeb
-from protocol_add_noise import XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles
+##ROB
+from pyworkflow.em.packages.xmipp3.protocol_preprocess.protocol_add_noise import XmippProtAddNoiseVolumes, XmippProtAddNoiseParticles
 from protocol_apply_alignment import XmippProtApplyAlignment
 from protocol_apply_transformation_matrix import XmippProtApplyTransformationMatrix
 from protocol_break_symmetry import XmippProtAngBreakSymmetry

--- a/pyworkflow/em/packages/xmipp3/protocol_preprocess/protocol_add_noise.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_preprocess/protocol_add_noise.py
@@ -28,7 +28,6 @@
 from os.path import basename
 from pyworkflow.utils import removeExt
 from pyworkflow.protocol.params import (PointerParam, EnumParam, FloatParam, LEVEL_ADVANCED)
-##from convert import writeSetOfParticles
 from pyworkflow.em.protocol.protocol_3d import ProtRefine3D
 from pyworkflow.em.data import Volume
 import pyworkflow.em as em

--- a/pyworkflow/em/packages/xmipp3/protocol_preprocess/protocol_add_noise.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_preprocess/protocol_add_noise.py
@@ -28,11 +28,11 @@
 from os.path import basename
 from pyworkflow.utils import removeExt
 from pyworkflow.protocol.params import (PointerParam, EnumParam, FloatParam, LEVEL_ADVANCED)
-from convert import writeSetOfParticles
+##from convert import writeSetOfParticles
 from pyworkflow.em.protocol.protocol_3d import ProtRefine3D
 from pyworkflow.em.data import Volume
 import pyworkflow.em as em
-from pyworkflow.em.packages.xmipp3.convert import readSetOfParticles
+from pyworkflow.em.packages.xmipp3.convert import writeSetOfParticles 
 
 
 


### PR DESCRIPTION
add_noise protocol has been moved from

pyworkflow/em/packages/xmipp3/

to

pyworkflow/em/packages/xmipp3/protocol_preprocess

This broke two imports

    import from add_noise in init.py
    import of convert in protocol_add_noise.py

The "moved" protocol did not arise any error because the system was able to find the compiled pyc in the old location. Of course new instalation failed because no binary file has present in the old location.

Test scipion test tests.em.protocols.test_protocols_add_noise.TestAddNoise was successful
