### PR TITLE
fix for error 'memcpy' was not declared in this scope

### DIFF
--- a/config/templates/scipion.template
+++ b/config/templates/scipion.template
@@ -84,7 +84,7 @@ MPI_INCLUDE = /usr/lib64/mpi/gcc/openmpi/include
 MPI_BINDIR = /usr/lib64/mpi/gcc/openmpi/bin
 
 # NVCC (CUDA) variables
-NVCC = nvcc --x cu
+NVCC = nvcc --x cu -D_FORCE_INLINES
 NVCC_INCLUDE = /usr/local/cuda/include
 NVCC_LIBDIR = /usr/local/cuda/lib64
 


### PR DESCRIPTION
Fix for error 'memcpy' was not declared in this scope when compiling with cuda enabled.

---

Apparently, /usr/include/string.h changed from glib2.22 to glibc2.23 (https://fossies.org/diffs/glibc/2.22_vs_2.23/string/string.h-diff.html). The added code comes at the bottom of the file and is:

#if defined __USE_GNU && defined __OPTIMIZE__ \
        && defined __extern_always_inline && __GNUC_PREREQ (3,2)
    # if !defined _FORCE_INLINES && !defined _HAVE_STRING_ARCH_mempcpy

    #undef mempcpy
    #undef __mempcpy
    #define mempcpy(dest, src, n) __mempcpy_inline (dest, src, n)
    #define __mempcpy(dest, src, n) __mempcpy_inline (dest, src, n)

    __extern_always_inline void *
    __mempcpy_inline (void *__restrict __dest,
                     const void *__restrict __src, size_t __n)
    {
      return (char *) memcpy (__dest, __src, __n) + __n;
    }

    # endif
    #endif


The ways I've seen to stop this new code from triggering the memcpy error are:

1 Just comment out this code
2 Add D_FORCE_INLINES to flags for NVCC