### PR TITLE
update config script so it can handle python3

### DIFF
--- a/pyworkflow/apps/pw_config.py
+++ b/pyworkflow/apps/pw_config.py
@@ -126,10 +126,10 @@ def checkNotify(Config, notify=False):
     notifyOn = Config.get('VARIABLES','SCIPION_NOTIFY')
     if notifyOn=='False':
         # This works for  Python 2.x. and Python 3
-        try: 
-           input = raw_input
-        except NameError: 
-             pass
+        if sys.version_info[0] >= 3:
+            get_input = input
+        else:
+            get_input = raw_input
         print("""-----------------------------------------------------------------
 -----------------------------------------------------------------
 It would be very helpful if you allow Scipion
@@ -150,7 +150,7 @@ We understand, of course, that you may not wish to have any
 information collected from you and we respect your privacy.
 """)
 
-        prompt = input("Press <enter> if you want to share data, otherwise press any key followed by <enter>: ")
+        prompt = get_input("Press <enter> if you want to share data, otherwise press any key followed by <enter>: ")
         if prompt == '':
             Config.set('VARIABLES','SCIPION_NOTIFY','True')
         print(yellow("Statistics Collection has been set to: %s"%Config.get('VARIABLES','SCIPION_NOTIFY')))


### PR DESCRIPTION
modify pw_config.py so it can handle python3.

The problem is the function raw_input (python2) vs input (python3) used to read the keyboard.

Note in order to check this it is not enough to launch the installation as

    python3 ./scipion config

or

   python2 ./scipion config

You need to create a virtual environment for python2 and python3 and switch between them. 

This is a bit scary because it does mean that if we run the script as

   python3 ./scipion install

 at some point the system python is called as "python" using the default path. That is, if two installation of python are set in the same machine we may start  the configuration using one python and change to another in the middle.

     (yes, I know the explanation is not crystal clear) 