### PR TITLE
New xmipp ctf estimation in streaming from branch release-1.1.facilities-devel

### DIFF
--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -100,7 +100,8 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
             if mic.getMicName() not in insertedDict:
                 # CTF estimation
                 stepId = self._insertFunctionStep('_estimateCTF', micFn, micDir,
-                                                  mic.getMicName(), prerequisites=[])
+                                                  mic.getMicName(),
+                                                  prerequisites=[])
                 estimDeps.append(stepId)
 
                 insertedDict[mic.getMicName()] = stepId
@@ -393,7 +394,7 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
             papers.append('Vargas2013a')
         return papers
 
-    # --------------------------- UTILS functions ---------------------------------------------------
+    # --------------------------- UTILS functions ------------------------------
     def _getMicDir(self, micName):
         """ Return an unique dir name for results of the micrograph. """
         return self._getExtraPath(removeBaseExt(micName))
@@ -461,8 +462,10 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                        }
             self._params = dict(self._params.items() + params2.items())
 
-            # Mapping between base protocol parameters and the package specific command options
-            self.__params = {'sampling_rate': self._params['samplingRate'] * downFactor,
+            # Mapping between base protocol parameters and the package specific
+            # command options
+            self.__params = {'sampling_rate': self._params['samplingRate']
+                                              * downFactor,
                              'downSamplingPerformed': downFactor,
                              'kV': self._params['voltage'],
                              'Cs': self._params['sphericalAberration'],
@@ -481,20 +484,32 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
 
     def _setPsdFiles(self, ctfModel, micDir):
         ctfModel._psdFile = String(self._getFileName('psd', micDir=micDir))
-        ctfModel._xmipp_enhanced_psd = String(self._getFileName('enhanced_psd', micDir=micDir))
-        ctfModel._xmipp_ctfmodel_quadrant = String(self._getFileName('ctfmodel_quadrant', micDir=micDir))
-        ctfModel._xmipp_ctfmodel_halfplane = String(self._getFileName('ctfmodel_halfplane', micDir=micDir))
+        ctfModel._xmipp_enhanced_psd = \
+            String(self._getFileName('enhanced_psd', micDir=micDir))
+        ctfModel._xmipp_ctfmodel_quadrant = \
+            String(self._getFileName('ctfmodel_quadrant', micDir=micDir))
+        ctfModel._xmipp_ctfmodel_halfplane = \
+            String(self._getFileName('ctfmodel_halfplane', micDir=micDir))
 
     def evaluateSingleMicrograph(self, micFn, micDir):
         fnCTF = self._getFileName('ctfparam', micDir=micDir)
         mdCTFparam = xmipp.MetaData(fnCTF)
         objId = mdCTFparam.firstObject()
         mdCTFparam.setValue(md.MDL_MICROGRAPH, micFn, objId)
-        mdCTFparam.setValue(md.MDL_PSD, str(self._getFileName('psd', micDir=micDir)), objId)
-        mdCTFparam.setValue(md.MDL_PSD_ENHANCED, str(self._getFileName('enhanced_psd', micDir=micDir)), objId)
-        mdCTFparam.setValue(md.MDL_CTF_MODEL, str(self._getFileName('ctfparam', micDir=micDir)), objId)
-        mdCTFparam.setValue(md.MDL_IMAGE1, str(self._getFileName('ctfmodel_quadrant', micDir=micDir)), objId)
-        mdCTFparam.setValue(md.MDL_IMAGE2, str(self._getFileName('ctfmodel_halfplane', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_PSD,
+                            str(self._getFileName('psd', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_PSD_ENHANCED,
+                            str(self._getFileName('enhanced_psd',
+                                                  micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_CTF_MODEL,
+                            str(self._getFileName('ctfparam',
+                                                  micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_IMAGE1,
+                            str(self._getFileName('ctfmodel_quadrant',
+                                                  micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_IMAGE2,
+                            str(self._getFileName('ctfmodel_halfplane',
+                                                  micDir=micDir)), objId)
 
         fnEval = self._getFileName('ctf', micDir=micDir)
         mdCTFparam.write(fnEval)
@@ -508,7 +523,8 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
         # Check if it is a good micrograph
         fnRejected = self._getTmpPath(basename(micFn + "_rejected.xmd"))
         self.runJob("xmipp_metadata_utilities",
-                    '-i %s --query select "%s" -o %s' % (fnEval, self._criterion, fnRejected))
+                    '-i %s --query select "%s" -o %s'
+                    % (fnEval, self._criterion, fnRejected))
 
         retval = True
         if not isMdEmpty(fnRejected):

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -185,14 +185,12 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
         ctfSet = self._loadOutputSet(em.SetOfCTF, fnOut)
 
         if newDone:
-            self._loadInputList()
             for micName in newDone:
 
                 for m in self.listOfMic:
                     if m.getMicName()==micName:
                         self.mic = m
                         break
-
                 micDir = self._getMicDir(micName)
                 fnCTF = self._getFileName('ctf', micDir=micDir)
                 if not exists(fnCTF):

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -100,23 +100,6 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                            'suspicious.')
 
     # --------------------------- INSERT steps functions -----------------------
-    def _insertEstimationSteps(self, insertedDict, inputMics):
-
-        estimDeps = []
-        self._defineValues()
-        self._prepareCommand()
-        # For each micrograph insert the steps to process it
-        for micFn, micDir, mic in self._iterMicrographs(inputMics):
-            if mic.getMicName() not in insertedDict:
-                # CTF estimation
-                stepId = self._insertFunctionStep('_estimateCTF', micFn, micDir,
-                                                  mic.getMicName(),
-                                                  prerequisites=[])
-                estimDeps.append(stepId)
-
-                insertedDict[mic.getMicName()] = stepId
-        return estimDeps
-
     def _stepsCheck(self):
         # The streaming is not allowed for recalculate CTF
         if self.recalculate:
@@ -186,12 +169,11 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
 
         if newDone:
             for micName in newDone:
-
                 for m in self.listOfMic:
-                    if m.getMicName()==micName:
+                    if m.getMicName() == micName:
                         self.mic = m
                         break
-                micDir = self._getMicDir(micName)
+                micDir = self._getMicrographDir(self.mic)
                 fnCTF = self._getFileName('ctf', micDir=micDir)
                 if not exists(fnCTF):
                     fnError = self._getFileName('ctfErrorParam', micDir=micDir)
@@ -260,8 +242,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                     downsampleList.append((ctfDownFactor + 1) / 2)
 
         deleteTmp = ""
-
-
+        
         for downFactor in downsampleList:
             # Downsample if necessary
             if downFactor != 1:
@@ -385,10 +366,6 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
         return papers
 
     # --------------------------- UTILS functions ------------------------------
-    def _getMicDir(self, micName):
-        """ Return an unique dir name for results of the micrograph. """
-        return self._getExtraPath(pwutils.path.removeBaseExt(micName))
-
     def _prepareArgs(self, params):
         self._args = ("--micrograph %(micFn)s --oroot %(micDir)s --sampling_rate "
                       "%(samplingRate)s --defocusU %(defocusU)f --defocus_range "

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -1,8 +1,7 @@
 # **************************************************************************
 # *
-# * Authors:     J.M. De la Rosa Trevin (jmdelarosa@cnb.csic.es)
-# *              Laura del Cano (ldelcano@cnb.csic.es)
-# *              Josue Gomez Blanco (jgomez@cnb.csic.es)
+# * Authors:     Carlos Oscar S. Sorzano (coss@cnb.csic.es)
+# *              Amaya Jimenez (ajimenez@cnb.csic.es)
 # *
 # * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
 # *
@@ -27,15 +26,16 @@
 # **************************************************************************
 
 from convert import *
+import pyworkflow.em as em
 from pyworkflow.em.packages.xmipp3.utils import isMdEmpty
 from pyworkflow.protocol.params import RelationParam
 
-
+#from pyworkflow.utils.path import FileLock
 
 class XmippProtCTFMicrographs(ProtCTFMicrographs):
     """ Protocol to estimate CTF on a set of micrographs using Xmipp. """
     _label = 'ctf estimation'
-    
+
     _criterion = ("ctfCritFirstZero<5 OR ctfCritMaxFreq>20 OR "
                   "ctfCritfirstZeroRatio<0.9 OR ctfCritfirstZeroRatio>1.1 OR "
                   "ctfCritFirstMinFirstZeroRatio>10 OR ctfCritCorr13<0 OR "
@@ -44,26 +44,26 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
 
     def __init__(self, **args):
         ProtCTFMicrographs.__init__(self, **args)
-    
+
     def _createFilenameTemplates(self):
-        prefix = join('%(micDir)s','xmipp_ctf')
+        prefix = join('%(micDir)s', 'xmipp_ctf')
         _templateDict = {
-                         # This templates are relative to a micDir
-                         'micrographs': 'micrographs.xmd',
-                         'prefix': prefix,
-                         'ctfparam': prefix +  '.ctfparam',
-                         'ctfErrorParam': prefix +  '_error.ctfparam',
-                         'psd': prefix + '.psd',
-                         'enhanced_psd': prefix + '_enhanced_psd.xmp',
-                         'ctfmodel_quadrant': prefix + '_ctfmodel_quadrant.xmp',
-                         'ctfmodel_halfplane': prefix + '_ctfmodel_halfplane.xmp',
-                         'ctf': prefix + '.xmd'
-                         }
+            # This templates are relative to a micDir
+            'micrographs': 'micrographs.xmd',
+            'prefix': prefix,
+            'ctfparam': prefix + '.ctfparam',
+            'ctfErrorParam': prefix + '_error.xmd',
+            'psd': prefix + '.psd',
+            'enhanced_psd': prefix + '_enhanced_psd.xmp',
+            'ctfmodel_quadrant': prefix + '_ctfmodel_quadrant.xmp',
+            'ctfmodel_halfplane': prefix + '_ctfmodel_halfplane.xmp',
+            'ctf': prefix + '.xmd'
+        }
         self._updateFilenamesDict(_templateDict)
-    
+
     def _defineProcessParams(self, form):
-        form.addParam('doInitialCTF', BooleanParam, default=False, 
-              label="Use defoci from a previous CTF estimation")
+        form.addParam('doInitialCTF', BooleanParam, default=False,
+                      label="Use defoci from a previous CTF estimation")
         form.addParam('ctfRelations', RelationParam, allowsNull=True,
                       condition='doInitialCTF',
                       relationName=RELATION_CTF,
@@ -87,27 +87,156 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                       label="Automatic rejection", expertLevel=LEVEL_ADVANCED,
                       help='Automatically reject micrographs whose CTF looks '
                            'suspicious.')
-    
-    def getInputMicrographs(self):
-        return self.inputMicrographs.get()
 
-    #--------------------------- INSERT steps functions ------------------------
-    def _insertFinalSteps(self, deps):
-        stepId = self._insertFunctionStep('sortPSDStep', prerequisites=deps)
-        return [stepId]
-    
-    def _getFirstJoinStepName(self):
-        # This function will be used for streamming, to check which is
-        # the first function that need to wait for all micrographs
-        # to have completed, this can be overriden in subclasses
-        # (ej in Xmipp 'sortPSDStep')
-        return 'sortPSDStep'
-        
-    #--------------------------- STEPS functions -------------------------------
+
+    # --------------------------- INSERT steps functions ------------------------
+    def _insertEstimationSteps(self, insertedDict, inputMics):
+
+        estimDeps = []
+        self._defineValues()
+        self._prepareCommand()
+        # For each micrograph insert the steps to process it
+        for micFn, micDir, mic in self._iterMicrographs(inputMics):
+            if mic.getMicName() not in insertedDict:
+                # CTF estimation
+                stepId = self._insertFunctionStep('_estimateCTF', micFn, micDir,
+                                                  mic.getMicName(), prerequisites=[])
+                estimDeps.append(stepId)
+
+                insertedDict[mic.getMicName()] = stepId
+
+        return estimDeps
+
+
+    def _stepsCheck(self):
+
+        # The streaming is not allowed for recalculate CTF
+        if self.recalculate:
+            return
+
+        # check if there are new micrographs and process them
+        self._checkNewInput()
+        self._checkNewOutput()
+        return
+
+
+    def _checkNewInput(self):
+        """ Check if there are new ctf to be processed and add the necessary
+        steps."""
+        micFile = self.inputMicrographs.get().getFileName()
+
+        now = datetime.now()
+        self.lastCheck = getattr(self, 'lastCheck', now)
+        mTime = datetime.fromtimestamp(os.path.getmtime(micFile))
+        self.debug('Last check: %s, modification: %s'
+                   % (pwutils.prettyTime(self.lastCheck),
+                      pwutils.prettyTime(mTime)))
+
+        # Open input micrographs.sqlite and close it as soon as possible
+        self._loadInputList()
+        # If the input micrographs.sqlite have not changed since our last check,
+        # it does not make sense to check for new input data
+        if self.lastCheck > mTime and hasattr(self, 'listOfMic'):
+            return None
+
+        self.lastCheck = now
+        newMic = any(mic.getMicName() not in self.insertedDict
+                     for mic in self.listOfMic)
+        outputStep = self._getFirstJoinStep()
+
+        if newMic:
+            fDeps = self._insertEstimationSteps(self.insertedDict,
+                                                  self.listOfMic)
+            if outputStep is not None:
+                outputStep.addPrerequisites(*fDeps)
+            self.updateSteps()
+
+
+
+    def _checkNewOutput(self):
+        """ Check for already estimated CTF and update the output set. """
+
+        # Load previously done items (from text file)
+        doneList = self._readDoneList()
+
+        # Check for newly done items
+        ctfListName = self._readtCtfName()
+
+        newDone = [ctfName for ctfName in ctfListName
+                   if ctfName not in doneList]
+        firstTime = len(doneList) == 0
+        allDone = len(doneList) + len(newDone)
+
+        # We have finished when there is not more input ctf (stream closed)
+        # and the number of processed ctf is equal to the number of inputs
+        self.finished = (self.isStreamClosed == Set.STREAM_CLOSED
+                         and allDone == len(self.listOfMic))
+        streamMode = Set.STREAM_CLOSED if self.finished else Set.STREAM_OPEN
+
+        # reading the outputs
+        fnOut = self._getPath('ctfs.sqlite')
+
+        #with FileLock(fnOut):
+
+        ctfSet = self._loadOutputSet(em.SetOfCTF, fnOut)
+
+        if newDone:
+            self._loadInputList()
+            for micName in newDone:
+
+                for m in self.listOfMic:
+                    if m.getMicName()==micName:
+                        self.mic = m
+                        break
+
+                micDir = self._getMicDir(micName)
+                fnCTF = self._getFileName('ctf', micDir=micDir)
+                if not exists(fnCTF):
+                    fnError = self._getFileName('ctfErrorParam', micDir=micDir)
+                    if not exists(fnError):
+                        self._createErrorCtfParam(micDir)
+                    mdCTF = md.MetaData(fnError)
+                else:
+                    mdCTF = md.MetaData(fnCTF)
+
+                ctfModel = mdToCTFModel(mdCTF, self.mic)
+                self._setPsdFiles(ctfModel, micDir)
+                ctfSet.append(ctfModel)
+
+            self._writeDoneList(newDone)
+
+        elif not self.finished:
+            # If we are not finished and no new output have been produced
+            # it does not make sense to proceed and updated the outputs
+            # so we exit from the function here
+            return
+
+        self._updateOutputSet('outputCTF', ctfSet, streamMode)
+
+        if firstTime:
+            # define relation just once
+            self._defineSourceRelation(self.inputMicrographs.get(), ctfSet)
+        else:
+            ctfSet.close()
+
+        if self.finished:  # Unlock createOutputStep if finished all jobs
+            outputStep = self._getFirstJoinStep()
+            if outputStep and outputStep.isWaiting():
+                outputStep.setStatus(STATUS_NEW)
+
+        ctfSet.close()
+        #AJ end FileLock
+
+    # --------------------------- STEPS functions -------------------------------
     def _estimateCTF(self, micFn, micDir, micName):
         """ Run the estimate CTF program """
-        localParams = self.__params.copy()
 
+        #AJ not a solution - ask this
+        #doneList = self._readDoneList()
+        #if micName in doneList:
+        #    return
+
+        localParams = self.__params.copy()
         if self.doInitialCTF:
             if self.ctfDict[micName] > 0:
                 localParams['defocusU'] = self.ctfDict[micName]
@@ -115,27 +244,28 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
         else:
             ma = self._params['maxDefocus']
             mi = self._params['minDefocus']
-            localParams['defocusU']= (ma + mi) / 2
-            localParams['defocus_range'] = (ma - mi)/ 2
-        
+            localParams['defocusU'] = (ma + mi) / 2
+            localParams['defocus_range'] = (ma - mi) / 2
+
         # Create micrograph dir under extra directory
         makePath(micDir)
         if not exists(micDir):
             raise Exception("No created dir: %s " % micDir)
 
-        finalName = micFn        
+        finalName = micFn
         ctfDownFactor = self.ctfDownFactor.get()
         downsampleList = [ctfDownFactor]
 
         if self.doCTFAutoDownsampling:
-            downsampleList.append(ctfDownFactor+1)
+            downsampleList.append(ctfDownFactor + 1)
             if ctfDownFactor >= 2:
-                downsampleList.append(ctfDownFactor-1)
+                downsampleList.append(ctfDownFactor - 1)
             else:
                 if ctfDownFactor > 1:
-                    downsampleList.append((ctfDownFactor+1)/2)
-    
+                    downsampleList.append((ctfDownFactor + 1) / 2)
+
         deleteTmp = ""
+
 
         for downFactor in downsampleList:
             # Downsample if necessary
@@ -146,13 +276,14 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                 self.runJob("xmipp_transform_downsample",
                             "-i %s -o %s --step %f --method fourier"
                             % (micFn, finalName, downFactor))
-                deleteTmp=finalName
-      
+                deleteTmp = finalName
+
             # Update _params dictionary with mic and micDir
             localParams['micFn'] = finalName
             localParams['micDir'] = self._getFileName('prefix', micDir=micDir)
-            localParams['samplingRate'] = self.inputMics.getSamplingRate() * downFactor
-            
+            localParams['samplingRate'] = \
+                self.inputMics.getSamplingRate() * downFactor
+
             # CTF estimation with Xmipp
             try:
                 self.runJob(self._program,
@@ -160,113 +291,69 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                             " --downSamplingPerformed %f" % downFactor)
             except Exception:
                 break
-            
+
+            toWrite=False
             # Check the quality of the estimation and reject it necessary
-            if self.evaluateSingleMicrograph(micFn,micDir):
+            if self.evaluateSingleMicrograph(micFn, micDir):
+                toWrite=True
                 break
-            
+
         if deleteTmp != "":
             cleanPath(deleteTmp)
-    
+
+        fnCTF = self._getFileName('ctf', micDir=micDir)
+        if os.path.exists(fnCTF) and toWrite:
+            fn = self._getCtfEstimationFile()
+            with open(fn, 'a') as f:
+                f.write('%s\n' % micName)
+
+
+    def createOutputStep(self):
+
+        if self.recalculate:
+            ctfSet = self._createSetOfCTF("_recalculated")
+            prot = self.continueRun.get() or self
+            micSet = prot.outputCTF.getMicrographs()
+            # We suppose this is reading the ctf selection
+            # (with enabled/disabled) to only consider the enabled ones
+            # in the final SetOfCTF
+            #TODO: maybe we can remove the need of the extra text file
+            # with the recalculate parameters
+            newCount = 0
+            for ctfModel in self.recalculateSet:
+                if ctfModel.isEnabled() and ctfModel.getObjComment():
+                    mic = ctfModel.getMicrograph()
+                    # Update the CTF models that where recalculated and append
+                    # later to the set, we don't want to copy the id here since
+                    # it is already correct
+                    newCtf = self._createCtfModel(mic)
+                    ctfModel.copy(newCtf, copyId=False)
+                    ctfModel.setEnabled(True)
+                    newCount += 1
+                ctfSet.append(ctfModel)
+            ctfSet.setMicrographs(micSet)
+            self._defineOutputs(outputCTF=ctfSet)
+            self._defineCtfRelation(micSet, ctfSet)
+            self._computeDefocusRange(ctfSet)
+            self.summaryVar.set("CTF Re-estimation of %d micrographs"
+                                % newCount)
+
+
+
     def _restimateCTF(self, micId):
         """ Run the estimate CTF program """
         ctfModel = self.recalculateSet[micId]
         self._prepareRecalCommand(ctfModel)
-        # CTF estimation with Xmipp                
+        # CTF estimation with Xmipp
         self.runJob(self._program, self._args % self._params)
-        
-        mic=ctfModel.getMicrograph()
+
+        mic = ctfModel.getMicrograph()
         micDir = self._getMicrographDir(mic)
-        self.evaluateSingleMicrograph(mic.getFileName(),micDir)
-    
-    def sortPSDStep(self):
-        # Gather all metadatas of all micrographs
-        md=xmipp.MetaData()
-        for _, micDir, mic in self._iterMicrographs():
-            fnCTF=self._getFileName('prefix', micDir=micDir)+".xmd"
-            enable=1
-            if not os.path.exists(fnCTF):
-                fnCTF = self._createErrorCtfParam(micDir)
-                enable=-1
-            mdCTF=xmipp.MetaData(fnCTF)
-            mdCTF.setValue(xmipp.MDL_ENABLED,enable,mdCTF.firstObject())
-            mdCTF.setValue(xmipp.MDL_MICROGRAPH_ID,long(mic.getObjId()),mdCTF.firstObject())
-            md.unionAll(mdCTF)
-        fnAllMicrographs=self._getPath("micrographs.xmd")
-        md.write(fnAllMicrographs)
-        
-        # Now evaluate them
-        self.runJob("xmipp_ctf_sort_psds","-i %s"%fnAllMicrographs)
-    
-        # And reject
-        fnRejected=self._getPath("micrographs_rejected.xmd")
-        self.runJob("xmipp_metadata_utilities",
-                    '-i %s --query select "%s" -o %s'
-                    % (fnAllMicrographs, self._criterion, fnRejected))
-        mdRejected = xmipp.MetaData(fnRejected)
-        self.someMicrographsRejected = mdRejected.size()>0
+        self.evaluateSingleMicrograph(mic.getFileName(), micDir)
 
-        if self.someMicrographsRejected:
-            rejectedMicrographs = mdRejected.getColumnValues(xmipp.MDL_MICROGRAPH_ID)
-            for mdid in md:
-                micId = md.getValue(xmipp.MDL_MICROGRAPH_ID,mdid)
-                if micId in rejectedMicrographs:
-                    md.setValue(xmipp.MDL_ENABLED,-1,mdid)
-                else:
-                    md.setValue(xmipp.MDL_ENABLED,1,mdid)
-        md.write(self._getPath("ctfs_selection.xmd"))
-        cleanPath(fnRejected)
-        
-    def _createOutputStep(self):
-        ctfSet = self._createSetOfCTF()
-        inputMics = self.inputMicrographs.get()
-        ctfSet.setMicrographs(inputMics)
-        defocusList = []
-        if self.doAutomaticRejection:
-            fn = self._getPath("micrographs.xmd")
-        else:
-            fn = self._getPath("ctfs_selection.xmd")
-        mdFn = md.MetaData(fn)
-        mdAux = md.MetaData()
-        
-        for _, micDir, mic in self._iterMicrographs():
-            if exists(self._getFileName('ctfparam', micDir=micDir)):
-                mdCTF = md.MetaData(self._getFileName('ctfparam', micDir=micDir))
-                mdQuality = md.MetaData(self._getFileName('ctf', micDir=micDir))
-                mdCTF.setValue(xmipp.MDL_CTF_CRIT_NONASTIGMATICVALIDITY,
-                               mdQuality.getValue(xmipp.MDL_CTF_CRIT_NONASTIGMATICVALIDITY,mdQuality.firstObject()),
-                               mdCTF.firstObject())
-                mdCTF.setValue(xmipp.MDL_CTF_CRIT_FIRSTMINIMUM_FIRSTZERO_DIFF_RATIO,
-                               mdQuality.getValue(xmipp.MDL_CTF_CRIT_FIRSTMINIMUM_FIRSTZERO_DIFF_RATIO,mdQuality.firstObject()),
-                               mdCTF.firstObject())
-            else:
-                fnError=self._getFileName('ctfErrorParam', micDir=micDir)
-                if not exists(fnError):
-                    self._createErrorCtfParam(micDir)
-                mdCTF = md.MetaData(fnError)
-            mdAux.importObjects( mdFn, md.MDValueEQ(md.MDL_MICROGRAPH_ID, long(mic.getObjId())))
-            mdAux.merge(mdCTF)
-            
-            mic.setSamplingRate(mdCTF.getValue(md.MDL_CTF_SAMPLING_RATE, 1))
-            
-            ctfModel = mdToCTFModel(mdAux, mic)
-            self._setPsdFiles(ctfModel, micDir)
-            ctfSet.append(ctfModel)
-            
-            # save the values of defocus for each micrograph in a list
-            defocusList.append(ctfModel.getDefocusU())
-            defocusList.append(ctfModel.getDefocusV())
-                
-        self._defineOutputs(outputCTF=ctfSet)
-        self._defineCtfRelation(inputMics, ctfSet)
-        self._computeDefocusRange(ctfSet)
 
-    def _checkNewCTFs(self, micSet):
-        # In Xmipp, we need to sort the resulting CTF at the end,
-        # so we can not update the output in streaming.
-        return None, None
-    
-    #--------------------------- INFO functions ----------------------------------------------------
+
+    # --------------------------- INFO functions --------------------------------
     def _validate(self):
         validateMsgs = []
         # downsampling factor must be greater than 1
@@ -278,59 +365,64 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                                     'of the CTF, the corresponding set of CTFs '
                                     'is needed')
         return validateMsgs
-    
+
     def _summary(self):
         summary = ProtCTFMicrographs._summary(self)
         if self.methodsVar.hasValue():
             summary.append(self.methodsVar.get())
         return summary
-    
+
     def _methods(self):
-        strMsg = "We calculated the CTF of micrographs %s using Xmipp [Sorzano2007a]" % self.getObjectTag('inputMicrographs')
+        strMsg = "We calculated the CTF of micrographs %s using Xmipp " \
+                 "[Sorzano2007a]" % self.getObjectTag('inputMicrographs')
         if self.doFastDefocus and not self.doInitialCTF:
-            strMsg += " with a fast defocus estimate [Vargas2013a]"
-        strMsg += "."
+            str += " with a fast defocus estimate [Vargas2013a]"
+        str += "."
 
         if self.methodsVar.hasValue():
             strMsg += " " + self.methodsVar.get()
-        
+
         if self.hasAttribute('outputCTF'):
-            strMsg += '\nOutput set is %s.'%self.getObjectTag('outputCTF')
-        
+            strMsg += '\nOutput set is %s.' % self.getObjectTag('outputCTF')
+
         return [strMsg]
-    
+
     def _citations(self):
         papers = ['Sorzano2007a']
         if self.doFastDefocus and not self.doInitialCTF:
             papers.append('Vargas2013a')
         return papers
-    
-    #--------------------------- UTILS functions ---------------------------------------------------
-    def _prepareArgs(self,params):
+
+    # --------------------------- UTILS functions ---------------------------------------------------
+    def _getMicDir(self, micName):
+        """ Return an unique dir name for results of the micrograph. """
+        return self._getExtraPath(removeBaseExt(micName))
+
+    def _prepareArgs(self, params):
         self._args = ("--micrograph %(micFn)s --oroot %(micDir)s --sampling_rate "
                       "%(samplingRate)s --defocusU %(defocusU)f --defocus_range "
                       "%(defocus_range)f --overlap 0.7 ")
-        
+
         for par, val in params.iteritems():
             self._args += " --%s %s" % (par, str(val))
-            
+
         if self.doFastDefocus and not self.doInitialCTF:
             self._args += " --fastDefocus"
 
     def _prepareCommand(self):
         self._createFilenameTemplates()
-        self._program = 'xmipp_ctf_estimate_from_micrograph'       
-        
+        self._program = 'xmipp_ctf_estimate_from_micrograph'
+
         # Mapping between base protocol parameters and the package specific
         # command options
         self.__params = {'kV': self._params['voltage'],
-                'Cs': self._params['sphericalAberration'],
-                'ctfmodelSize': self._params['windowSize'],
-                'Q0': self._params['ampContrast'],
-                'min_freq': self._params['lowRes'],
-                'max_freq': self._params['highRes'],
-                'pieceDim': self._params['windowSize']
-                }
+                         'Cs': self._params['sphericalAberration'],
+                         'ctfmodelSize': self._params['windowSize'],
+                         'Q0': self._params['ampContrast'],
+                         'min_freq': self._params['lowRes'],
+                         'max_freq': self._params['highRes'],
+                         'pieceDim': self._params['windowSize']
+                         }
         self._prepareArgs(self.__params)
 
         if self.ctfRelations.hasValue():
@@ -338,22 +430,22 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
             for ctf in self.ctfRelations.get():
                 ctfName = ctf.getMicrograph().getMicName()
                 self.ctfDict[ctfName] = ctf.getDefocusU()
-                    
+
     def _prepareRecalCommand(self, ctfModel):
         if self.recalculate:
             self._defineRecalValues(ctfModel)
             self._createFilenameTemplates()
-            self._program = 'xmipp_ctf_estimate_from_psd'       
+            self._program = 'xmipp_ctf_estimate_from_psd'
             self._args = "--psd %(psdFn)s "
             line = ctfModel.getObjComment().split()
-    
+
             # get the size and the image of psd
-    
+
             imgPsd = ctfModel.getPsdFile()
             psdFile = basename(imgPsd)
             imgh = ImageHandler()
             size, _, _, _ = imgh.getDimensions(imgPsd)
-            
+
             mic = ctfModel.getMicrograph()
             micDir = self._getMicrographDir(mic)
             fnCTFparam = self._getFileName('ctfparam', micDir=micDir)
@@ -361,16 +453,16 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
             downFactor = mdCTFParam.getValue(xmipp.MDL_CTF_DOWNSAMPLE_PERFORMED,
                                              mdCTFParam.firstObject())
             # cleanPath(fnCTFparam)
-            
+
             params2 = {'psdFn': join(micDir, psdFile),
                        'defocusU': float(line[0]),
                        'defocusV': float(line[1]),
                        'angle': line[2],
-                      }
+                       }
             self._params = dict(self._params.items() + params2.items())
-            
+
             # Mapping between base protocol parameters and the package specific command options
-            self.__params = {'sampling_rate': self._params['samplingRate']*downFactor,
+            self.__params = {'sampling_rate': self._params['samplingRate'] * downFactor,
                              'downSamplingPerformed': downFactor,
                              'kV': self._params['voltage'],
                              'Cs': self._params['sphericalAberration'],
@@ -382,75 +474,144 @@ class XmippProtCTFMicrographs(ProtCTFMicrographs):
                              'Q0': self._params['ampContrast'],
                              'defocus_range': 5000,
                              'ctfmodelSize': size
-                            }
-            
+                             }
+
             for par, val in self.__params.iteritems():
                 self._args += " --%s %s" % (par, str(val))
-    
+
     def _setPsdFiles(self, ctfModel, micDir):
         ctfModel._psdFile = String(self._getFileName('psd', micDir=micDir))
         ctfModel._xmipp_enhanced_psd = String(self._getFileName('enhanced_psd', micDir=micDir))
         ctfModel._xmipp_ctfmodel_quadrant = String(self._getFileName('ctfmodel_quadrant', micDir=micDir))
         ctfModel._xmipp_ctfmodel_halfplane = String(self._getFileName('ctfmodel_halfplane', micDir=micDir))
-    
-    def evaluateSingleMicrograph(self,micFn,micDir):
-        mdCTFparam=xmipp.MetaData(self._getFileName('ctfparam', micDir=micDir))
-        ctfDownFactor=mdCTFparam.getValue(xmipp.MDL_CTF_DOWNSAMPLE_PERFORMED,mdCTFparam.firstObject())
-        
-        mdEval = md.MetaData()
-        objId = mdEval.addObject()
 
-# Check what happen with movies        
-#             if md.MDL_TYPE == md.MDL_MICROGRAPH_MOVIE:
-#                 mdEval.setValue(md.MDL_MICROGRAPH_MOVIE, micFn, objId)
-#                 mdEval.setValue(md.MDL_MICROGRAPH,('%05d@%s'%(1, micFn)), objId)
-#             else:
-        mdEval.setValue(md.MDL_MICROGRAPH, micFn, objId)
-        
-        mdEval.setValue(md.MDL_PSD, str(self._getFileName('psd', micDir=micDir)), objId)
-        mdEval.setValue(md.MDL_PSD_ENHANCED, str(self._getFileName('enhanced_psd', micDir=micDir)), objId)
-        mdEval.setValue(md.MDL_CTF_MODEL, str(self._getFileName('ctfparam', micDir=micDir)), objId)
-        mdEval.setValue(md.MDL_IMAGE1, str(self._getFileName('ctfmodel_quadrant', micDir=micDir)), objId)
-        mdEval.setValue(md.MDL_IMAGE2, str(self._getFileName('ctfmodel_halfplane', micDir=micDir)), objId)
-        mdEval.setValue(md.MDL_CTF_DOWNSAMPLE_PERFORMED,float(ctfDownFactor), objId)
+    def evaluateSingleMicrograph(self, micFn, micDir):
+        fnCTF = self._getFileName('ctfparam', micDir=micDir)
+        mdCTFparam = xmipp.MetaData(fnCTF)
+        objId = mdCTFparam.firstObject()
+        mdCTFparam.setValue(md.MDL_MICROGRAPH, micFn, objId)
+        mdCTFparam.setValue(md.MDL_PSD, str(self._getFileName('psd', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_PSD_ENHANCED, str(self._getFileName('enhanced_psd', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_CTF_MODEL, str(self._getFileName('ctfparam', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_IMAGE1, str(self._getFileName('ctfmodel_quadrant', micDir=micDir)), objId)
+        mdCTFparam.setValue(md.MDL_IMAGE2, str(self._getFileName('ctfmodel_halfplane', micDir=micDir)), objId)
+
         fnEval = self._getFileName('ctf', micDir=micDir)
-        mdEval.write(fnEval)
-        
+        mdCTFparam.write(fnEval)
+
         # Evaluate if estimated ctf is good enough
-        # self.runJob("xmipp_ctf_sort_psds","-i %s --downsampling %f"%(fnEval,ctfDownFactor))   
         try:
-            self.runJob("xmipp_ctf_sort_psds","-i %s"%(fnEval))
+            self.runJob("xmipp_ctf_sort_psds", "-i %s" % (fnEval))
         except Exception:
             pass
-#             print >> sys.stderr, "xmipp_ctf_sort_psds has been Failed!"
-#             raise ex
 
         # Check if it is a good micrograph
-        fnRejected = self._getTmpPath(basename(micFn +"_rejected.xmd"))
-        self.runJob("xmipp_metadata_utilities",'-i %s --query select "%s" -o %s' % (fnEval, self._criterion, fnRejected))
-        
-        retval=True
-        
+        fnRejected = self._getTmpPath(basename(micFn + "_rejected.xmd"))
+        self.runJob("xmipp_metadata_utilities",
+                    '-i %s --query select "%s" -o %s' % (fnEval, self._criterion, fnRejected))
+
+        retval = True
         if not isMdEmpty(fnRejected):
-            mdCTF = md.MetaData(fnEval)
-            mdCTF.setValue(md.MDL_ENABLED, -1, mdCTF.firstObject())
-            mdCTF.write(fnEval)
-            retval=False
+            mdCTFparam = md.MetaData(fnEval)
+            mdCTFparam.setValue(md.MDL_ENABLED, -1, mdCTFparam.firstObject())
+            mdCTFparam.write(fnEval)
+            retval = False
+
         cleanPath(fnRejected)
+
         return retval
-    
+
+    def _readDoneList(self):
+        """ Read from a text file the id's of the items that have been done. """
+        doneFile = self._getAllDone()
+        doneList = []
+        # Check what items have been previously done
+        if os.path.exists(doneFile):
+            with open(doneFile) as f:
+                doneList += [line.strip() for line in f]
+
+        return doneList
+
+    def _writeDoneList(self, ctfNameList):
+        """ Write to a text file the items that have been done. """
+        doneFile = self._getAllDone()
+        with open(doneFile, 'a') as f:
+            for ctfName in ctfNameList:
+                f.write('%s\n' % ctfName)
+
+    def _getAllDone(self):
+        return self._getExtraPath('DONE_all.TXT')
+
+    def _getCtfEstimationFile(self):
+        return self._getExtraPath('estimation-ctf.txt')
+
+    def _readtCtfName(self):
+        fn = self._getCtfEstimationFile()
+        ctfList = []
+        # Check what items have been previously done
+        if os.path.exists(fn):
+            with open(fn) as f:
+                ctfList += [line.strip() for line in f]
+        return ctfList
+
+    def _loadInputList(self):
+        """ Load the input set of micrographs and create a list. """
+        micSet = self._loadInputMicSet()
+        self.isStreamClosed = micSet.getStreamState()
+        self.listOfMic = [m.clone() for m in micSet]
+        micSet.close()
+        self.debug("Closed db.")
+
+    def _loadInputMicSet(self):
+        micFile = self.inputMicrographs().get().getFileName()
+        self.debug("Loading input db: %s" % micFile)
+        micSet = em.SetOfMicrographs(filename=micFile)
+        micSet.loadAllProperties()
+        return micSet
+
+    def _loadOutputSet(self, SetClass, setFile):
+        """
+        Load the output set if it exists or create a new one.
+        """
+        #setFile = self._getPath(baseName)
+
+        if os.path.exists(setFile):
+            outputSet = SetClass(filename=setFile)
+            if outputSet.getSize()>0:
+                outputSet.loadAllProperties()
+            outputSet.enableAppend()
+        else:
+            outputSet = SetClass(filename=setFile)
+            outputSet.setStreamState(outputSet.STREAM_OPEN)
+
+        micSet = self.inputMicrographs.get()
+
+        if isinstance(outputSet, em.SetOfMicrographs):
+            outputSet.copyInfo(micSet)
+        elif isinstance(outputSet, em.SetOfCTF):
+            outputSet.setMicrographs(micSet)
+
+        return outputSet
+
+    def _loadInputMicSet(self):
+        micFile = self.inputMicrographs.get().getFileName()
+        self.debug("Loading input db: %s" % micFile)
+        micSet = em.SetOfMicrographs(filename=micFile)
+        micSet.loadAllProperties()
+        return micSet
+
     def _createCtfModel(self, mic):
         micDir = self._getMicrographDir(mic)
         ctfparam = self._getFileName('ctfparam', micDir=micDir)
         ctfModel2 = readCTFModel(ctfparam, mic)
         self._setPsdFiles(ctfModel2, micDir)
         return ctfModel2
-    
+
     def _createErrorCtfParam(self, micDir):
-                ctfparam = self._getFileName('ctfErrorParam', micDir=micDir)
-                f = open(ctfparam, 'w+')
-                lines = """# XMIPP_STAR_1 * 
-# 
+        ctfparam = self._getFileName('ctfErrorParam', micDir=micDir)
+        f = open(ctfparam, 'w+')
+        lines = """# XMIPP_STAR_1 *
+#
 data_fullMicrograph
  _ctfSamplingRate -999
  _ctfVoltage -999
@@ -466,6 +627,9 @@ data_fullMicrograph
  _ctfTransversalDisplacement -999
  _ctfQ0 -999
  _ctfK -999
+ _ctfEnvR0 -999
+ _ctfEnvR1 -999
+ _ctfEnvR2 -999
  _ctfBgGaussianK -999
  _ctfBgGaussianSigmaU -999
  _ctfBgGaussianSigmaV -999
@@ -483,6 +647,9 @@ data_fullMicrograph
  _ctfBgGaussian2CU -999
  _ctfBgGaussian2CV -999
  _ctfBgGaussian2Angle -999
+ _ctfBgR1 -999
+ _ctfBgR2 -999
+ _ctfBgR3 -999
  _ctfX0 -999
  _ctfXF -999
  _ctfY0 -999
@@ -493,7 +660,25 @@ data_fullMicrograph
  _ctfCritPsdStdQ -999
  _ctfCritPsdPCA1 -999
  _ctfCritPsdPCARuns -999
+ _micrograph NULL
+ _psd NULL
+ _psdEnhanced NULL
+ _ctfModel NULL
+ _image1 NULL
+ _image2 NULL
+ _enabled -1
+ _ctfCritFirstZero -999
+ _ctfCritMaxFreq -999
+ _ctfCritDamping -999
+ _ctfCritfirstZeroRatio -999
+ _ctfEnvelopePlot -999
+ _ctfCritFirstMinFirstZeroRatio -999
+ _ctfCritCtfMargin -999
+ _ctfCritNonAstigmaticValidty -999
+ _ctfCritPsdCorr90 -999
+ _ctfCritPsdInt -999
+ _ctfCritNormality -999
 """
-                f.write(lines)
-                f.close()
-                return ctfparam
+        f.write(lines)
+        f.close()
+        return ctfparam

--- a/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
@@ -95,34 +95,6 @@ class TestCtfStreaming(BaseTest):
 
 
 
-        while not protCTF.hasAttribute('outputCTF'):
-            time.sleep(10)
-            protCTF = self._updateProtocol(protCTF)
-
-        #ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
-
-        #while not (ctfSet.getSize() >0):
-        #    time.sleep(10)
-        #    protCTF = self._updateProtocol(protCTF)
-        #    ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
-
-        #kwargs = {
-        #    'maxDefocus': 40000,
-        #    'minDefocus': 1000,
-        #    'astigmatism': 1000,
-        #    'resolution': 4
-        #}
-
-        #protCTFSel = self.newProtocol(XmippProtCTFSelection, **kwargs)
-        #protCTFSel.inputCTFs.set(protCTF.outputCTF)
-        #self.proj.launchProtocol(protCTFSel)
-
-        #while not (protCTFSel.hasAttribute('outputCTF') and protCTFSel.hasAttribute('outputMicrograph')):
-        #    time.sleep(10)
-        #    protCTFSel = self._updateProtocol(protCTFSel)
-
-
-
 ######################### AJ CHECKING OUTPUT OF NEW STREAMING PROTOCOL ##############################
 
 

--- a/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
@@ -1,0 +1,152 @@
+# ***************************************************************************
+# *
+# * Authors:     Amaya Jimenez (ajimenez@cnb.csic.es)
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# ***************************************************************************/
+
+import time
+import os
+
+from pyworkflow.tests import BaseTest, setupTestProject
+from pyworkflow.em.protocol import ProtCreateStreamData
+from pyworkflow.protocol import getProtocolFromDb
+from pyworkflow.em.packages.xmipp3 import XmippProtCTFMicrographs, XmippProtCTFSelection
+from pyworkflow.em.data import SetOfCTF, SetOfMicrographs
+
+
+# Load the number of movies for the simulation, by default equal 5, but
+# can be modified in the environement
+
+MICS = os.environ.get('SCIPION_TEST_MICS', 5)
+
+CTF_SQLITE = "ctfs.sqlite"
+MIC_SQLITE = "micrographs.sqlite"
+
+
+class TestCtfStreaming(BaseTest):
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+
+    def _updateProtocol(self, prot):
+        prot2 = getProtocolFromDb(prot.getProject().path,
+                                  prot.getDbPath(),
+                                  prot.getObjId())
+        # Close DB connections
+        prot2.getProject().closeMapper()
+        prot2.closeMappers()
+        return prot2
+
+    def test_pattern(self):
+        """ Import several Particles from a given pattern.
+        """
+        kwargs = {'xDim': 1024,
+                  'yDim': 1024,
+                  'nDim': MICS,
+                  'samplingRate': 3.0,
+                  'creationInterval': 30,
+                  'delay':0,
+                  'setof': 0 # SetOfMicrographs
+                  }
+
+        #create input micrographs
+        protStream = self.newProtocol(ProtCreateStreamData, **kwargs)
+        protStream.setObjLabel('create Stream Mic')
+        self.proj.launchProtocol(protStream,wait=False)
+
+        counter=1
+        while not protStream.hasAttribute('outputMicrographs'):
+            time.sleep(10)
+            protStream = self._updateProtocol(protStream)
+            if counter > 100:
+                break
+            counter += 1
+
+
+
+
+######################### AJ START NEW STREAMING PROTOCOL #########################################
+
+        kwargs = {
+            'numberOfThreads': 5}
+
+        protCTF = self.newProtocol(XmippProtCTFMicrographs, **kwargs)
+        protCTF.inputMicrographs.set(protStream.outputMicrographs)
+        self.proj.launchProtocol(protCTF)
+
+####################################################################################################
+
+
+
+        while not protCTF.hasAttribute('outputCTF'):
+            time.sleep(10)
+            protCTF = self._updateProtocol(protCTF)
+
+        #ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
+
+        #while not (ctfSet.getSize() >0):
+        #    time.sleep(10)
+        #    protCTF = self._updateProtocol(protCTF)
+        #    ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
+
+        #kwargs = {
+        #    'maxDefocus': 40000,
+        #    'minDefocus': 1000,
+        #    'astigmatism': 1000,
+        #    'resolution': 4
+        #}
+
+        #protCTFSel = self.newProtocol(XmippProtCTFSelection, **kwargs)
+        #protCTFSel.inputCTFs.set(protCTF.outputCTF)
+        #self.proj.launchProtocol(protCTFSel)
+
+        #while not (protCTFSel.hasAttribute('outputCTF') and protCTFSel.hasAttribute('outputMicrograph')):
+        #    time.sleep(10)
+        #    protCTFSel = self._updateProtocol(protCTFSel)
+
+
+
+######################### AJ CHECKING OUTPUT OF NEW STREAMING PROTOCOL ##############################
+
+
+        micSet = SetOfMicrographs(filename=protStream._getPath(MIC_SQLITE))
+        ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
+
+        while not (ctfSet.getSize() == micSet.getSize()):
+            time.sleep(10)
+            protCTF = self._updateProtocol(protCTF)
+            micSet = SetOfMicrographs(filename=protStream._getPath(MIC_SQLITE))
+            ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
+
+        ctfSet = SetOfCTF(filename=protCTF._getPath(CTF_SQLITE))
+
+        baseFn = protCTF._getPath(CTF_SQLITE)
+        self.assertTrue(os.path.isfile(baseFn))
+
+        self.assertEqual(ctfSet.getSize(), MICS)
+
+        for ctf in ctfSet:
+            self.assertNotEqual(ctf._xmipp_ctfCritMaxFreq.get(), None)
+            self.assertNotEqual(ctf.isEnabled(), None)
+            self.assertNotEqual(ctf._defocusU.get(), None)
+            self.assertNotEqual(ctf._defocusV.get(), None)
+            self.assertNotEqual(ctf._defocusRatio.get(), None)
+
+####################################################################################################

--- a/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_ctf_streaming.py
@@ -27,7 +27,7 @@ import os
 from pyworkflow.tests import BaseTest, setupTestProject
 from pyworkflow.em.protocol import ProtCreateStreamData
 from pyworkflow.protocol import getProtocolFromDb
-from pyworkflow.em.packages.xmipp3 import XmippProtCTFMicrographs, XmippProtCTFSelection
+from pyworkflow.em.packages.xmipp3 import XmippProtCTFMicrographs
 from pyworkflow.em.data import SetOfCTF, SetOfMicrographs
 
 
@@ -82,7 +82,7 @@ class TestCtfStreaming(BaseTest):
 
 
 
-######################### AJ START NEW STREAMING PROTOCOL #########################################
+######################### AJ START NEW STREAMING PROTOCOL ######################
 
         kwargs = {
             'numberOfThreads': 5}
@@ -91,11 +91,11 @@ class TestCtfStreaming(BaseTest):
         protCTF.inputMicrographs.set(protStream.outputMicrographs)
         self.proj.launchProtocol(protCTF)
 
-####################################################################################################
+################################################################################
 
 
 
-######################### AJ CHECKING OUTPUT OF NEW STREAMING PROTOCOL ##############################
+######################### AJ CHECKING OUTPUT OF NEW STREAMING PROTOCOL #########
 
 
         micSet = SetOfMicrographs(filename=protStream._getPath(MIC_SQLITE))
@@ -121,4 +121,4 @@ class TestCtfStreaming(BaseTest):
             self.assertNotEqual(ctf._defocusV.get(), None)
             self.assertNotEqual(ctf._defocusRatio.get(), None)
 
-####################################################################################################
+################################################################################


### PR DESCRIPTION
Added the xmipp ctf estimation protocol in streaming (protocol_ctf_micrographs). This time coming from the branch release-1.1.facilities-devel. 
The code has been modified following the recommendations of @josuegbl
A simple test to chek the performance of the new protocol is also included in test_protocols_ctf_streaming.