### PR TITLE
Showj fixes when visualizing .star files

### DIFF
--- a/software/em/xmipp/java/src/xmipp/jni/MetaData.java
+++ b/software/em/xmipp/java/src/xmipp/jni/MetaData.java
@@ -488,6 +488,9 @@ public class MetaData {
 	/** Add new column to MetaData */
 	public native void addLabel(int label);
 
+	/** Rename a column off the MetaData */
+	public native void renameColumn(int oldLabel, int newLabel);
+
 	/** Get the average and std images, result is left on input image */
 	public native void getStatsImages(ImageGeneric imageAvg,
 			ImageGeneric imageStd, boolean applyGeo, boolean wrap, int label);
@@ -512,6 +515,8 @@ public class MetaData {
 	 * @
 	 */
 	public native void fillConstant(int label, String value);
+
+
 
 	/**
 	 * Fill column in a random way

--- a/software/em/xmipp/java/src/xmipp/viewer/models/GalleryData.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/models/GalleryData.java
@@ -1808,7 +1808,7 @@ public class GalleryData {
         {
 	        shiftx = md.getValueDouble(MDLabel.RLN_ORIENT_ORIGIN_X, id);
 	        shifty = md.getValueDouble(MDLabel.RLN_ORIENT_ORIGIN_Y, id);
-	        psiangle = md.getValueDouble(MDLabel.RLN_ORIENT_PSI, id);
+	        psiangle = -1 * md.getValueDouble(MDLabel.RLN_ORIENT_PSI, id);
 	        flip = md.getValueBoolean(MDLabel.MDL_FLIP, id);
         }
         else

--- a/software/em/xmipp/java/src/xmipp/viewer/windows/ExportImagesJDialog.java
+++ b/software/em/xmipp/java/src/xmipp/viewer/windows/ExportImagesJDialog.java
@@ -162,7 +162,25 @@ public class ExportImagesJDialog extends JDialog{
                     	}
                     	else
                     		md = frame.data.getMd();
-                    	
+
+                        // Relion rlnAnglePsi is inverse as how we expect it in Xmipp
+                        // that's why we need to invert the angle before exporting particles
+                        System.out.println("Exporting metadata to: " + path);
+
+                    	if (md.containsLabel(MetaData.GEOMETRY_RELION_LABELS))
+                    	{
+                    	    // Since we need to modify the metadata, let's make a copy
+                    	    // Since the copy constructor is not ported to the binding
+                    	    // I will use this dirty way with unionAll
+                    	    MetaData md2 = new MetaData();
+                    	    md2.unionAll(md);
+                    	    md = md2;
+                            md.operate("rlnAnglePsi=rlnAnglePsi*-1");
+                            md.renameColumn(MDLabel.RLN_ORIENT_ORIGIN_X, MDLabel.MDL_SHIFT_X);
+                            md.renameColumn(MDLabel.RLN_ORIENT_ORIGIN_Y, MDLabel.MDL_SHIFT_Y);
+                            md.renameColumn(MDLabel.RLN_ORIENT_PSI, MDLabel.MDL_ANGLE_PSI);
+                        }
+
                     	md.writeMdToStack(path, applygeochb.isSelected(), frame.data.isWrap(), label);
 
                     } catch (Exception ex) {

--- a/software/em/xmipp/libraries/bindings/java/xmipp_MetaData.cpp
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_MetaData.cpp
@@ -797,6 +797,17 @@ JNIEXPORT void JNICALL Java_xmipp_jni_MetaData_addLabel(JNIEnv *env, jobject job
     XMIPP_JAVA_CATCH;
 }
 
+JNIEXPORT void JNICALL Java_xmipp_jni_MetaData_renameColumn(JNIEnv *env, jobject jobj, jint oldLabel, jint newLabel)
+{
+    MetaData *md = GET_INTERNAL_METADATA(jobj);
+
+    XMIPP_JAVA_TRY
+    {
+        md->renameColumn((MDLabel)oldLabel, (MDLabel)newLabel);
+    }
+    XMIPP_JAVA_CATCH;
+}
+
 JNIEXPORT void JNICALL Java_xmipp_jni_MetaData_getStatsImages
 (JNIEnv *env, jobject jmetadata,
  jobject jimageAvg, jobject jimageStd, jboolean applyGeo, jboolean wrap, jint label)
@@ -821,9 +832,8 @@ JNIEXPORT void JNICALL Java_xmipp_jni_MetaData_writeMdToStack
     XMIPP_JAVA_TRY
     {
         MetaData * md = GET_INTERNAL_METADATA(jmetadata);
-        jboolean aux=false;
+        jboolean aux = false;
         const char * fnChars = env->GetStringUTFChars(jfilename, &aux);
-        // FileName fn = fnChars;
         writeMdToStack(*md, fnChars, applyGeo, wrap, (MDLabel)label);
     }
     XMIPP_JAVA_CATCH;

--- a/software/em/xmipp/libraries/bindings/java/xmipp_MetaData.h
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_MetaData.h
@@ -392,6 +392,13 @@ extern "C"
 
     /*
      * Class:     xmipp_MetaData
+     * Method:    renameColumn
+     * Signature: (V)II
+     */
+    JNIEXPORT void JNICALL Java_xmipp_jni_MetaData_renameColumn
+    (JNIEnv *, jobject, jint, jint);
+    /*
+     * Class:     xmipp_MetaData
      * Method:    getPCAbasis
      * Signature: (Lxmipp/ImageGeneric;)V
      */


### PR DESCRIPTION
Changes in this PR:
* In showj (MetaDataGallery class) now the Relion rlnAnglePsi is multiplied by -1 to be understood as Xmipp convention.
* When exporting stack of images and applying the geometry...and using a star file...change the Relion labels to the expected Xmipp ones (and multiply by -1 as well rlnAnglePsi)
* For renaming the columns, the 'renameColumn'  function was added to the binding.

Still, there is a bit confusing behavior when showing classes 2D:
* If open the images of a class, using "Open images" it shows fine
* If open the images of a class, from the combobox, it will not apply the geometry by default (since the classes block does not have geometry)
