### PR TITLE
Fix parse gctf

### DIFF
--- a/pyworkflow/em/packages/gctf/convert.py
+++ b/pyworkflow/em/packages/gctf/convert.py
@@ -75,7 +75,7 @@ def parseGctfOutput(filename):
                 # Take ctfResolution as a tuple
                 # that is the last value in the line
                 # but remove escape characters first
-                result[5] = float(line.strip().split()[-1])
+                result[5] = float(line.strip().split()[-2])
                 break
         f.close()
     else:

--- a/pyworkflow/em/packages/gctf/convert.py
+++ b/pyworkflow/em/packages/gctf/convert.py
@@ -51,32 +51,37 @@ def parseGctfOutput(filename):
     """ Retrieve defocus U, V, angle, crossCorrelation
     and ctfResolution from the output file of the Gctf execution.
     """
-    result = None
-    result1 = ()
-    ansi_escape = re.compile(r'\x1b[^m]*m')
+
     if os.path.exists(filename):
+        # Create an empty list with: defU, defV, angle, CC and resolution
+        result = [0.] * 6
         f = open(filename)
         for line in f:
             if 'Final Values' in line:
+                parts = line.strip().split()
                 # line = DefocusU, DefocusV, Angle, crossCorrelation, Final, Values
                 # OR
                 # line = DefocusU, DefocusV, Angle, ctfPhaseShift, crossCorrelation, Final, Values
                 length = len(line.split())
-                if length == 6:
-                    result1 = tuple(map(float, line.split()[:4]))
-                    result1 += (.0,)  # ctfPhaseShift = 0
+                # Always map defU, defV and angle
+                result[0:3] = map(float, parts[0:3])
+
+                if parts[4] == 'Final': # no ctfPhaseShift
+                    result[3] = float(parts[3])
                 else:
-                    result1 = tuple(map(float, line.split()[:3]))
-                    result1 += tuple(map(float, (line.split()[4], line.split()[3])))
+                    result[3] = float(parts[4]) # CC is now in position 4
+                    result[4] = float(parts[3]) # get ctfPhaseShift
             if 'Resolution limit estimated by EPA' in line:
                 # Take ctfResolution as a tuple
                 # that is the last value in the line
                 # but remove escape characters first
-                result2 = ansi_escape.sub('', line)
-                result3 = tuple(map(float,result2.split()[-1:]))
-                result = result1 + result3
+                result[5] = float(line.strip().split()[-1])
                 break
         f.close()
+    else:
+        result = None
+        print "Warning: Missing file: ", filename
+
     return result
 
 


### PR DESCRIPTION
@azazellochg I has fixed a bug in parsing Gctf log files.
When the 'High resolution refinement' and not the 'Phase shift estimation' the line produced was as below:

23846.26    23525.42       61.84    0.521613  Final Values (Hres refine)

Adding the extra '(Hres refine)' string and making the number of elements after split greater...and broken the current parsing. 

I have changed the parsing a little bit and this error is fixed. Can you double check my changes to make sure it is working as expected? (I have passed the Gctf tests already)