### PR TITLE
Added variance features

### DIFF
--- a/software/em/xmipp/libraries/data/metadata_label.h
+++ b/software/em/xmipp/libraries/data/metadata_label.h
@@ -375,6 +375,7 @@ enum MDLabel
     MDL_SCORE_BY_LBP,  ///< Feature vectors used to classify particles (vector double)
     MDL_SCORE_BY_MIRROR, ///< score by mirror (double)
     MDL_SCORE_BY_SCREENING, ///< Feature vectors used to classify particles (vector double)
+    MDL_SCORE_BY_VARIANCE,  ///< Feature vectors used to classify particles (vector double)
     MDL_SCORE_BY_ZERNIKE,  ///< Feature vectors used to classify particles (vector double)
     MDL_SCORE_BY_ZSCORE,
     MDL_SELFILE, ///< Name of an image (std::string)
@@ -1817,6 +1818,7 @@ private:
         MDL::addLabel(MDL_SCORE_BY_LBP, LABEL_VECTOR_DOUBLE, "lbpFeatures");
         MDL::addLabel(MDL_SCORE_BY_MIRROR, LABEL_DOUBLE, "scoreByMirror");
         MDL::addLabel(MDL_SCORE_BY_SCREENING, LABEL_VECTOR_DOUBLE, "screenFeatures");
+        MDL::addLabel(MDL_SCORE_BY_VARIANCE, LABEL_VECTOR_DOUBLE, "varianceFeatures");
         MDL::addLabel(MDL_SCORE_BY_ZERNIKE, LABEL_VECTOR_DOUBLE, "zernikeMoments");
 		MDL::addLabel(MDL_SCORE_BY_ZSCORE, LABEL_DOUBLE, "scoreByZScore");
 

--- a/software/em/xmipp/libraries/reconstruction/classify_extract_features.cpp
+++ b/software/em/xmipp/libraries/reconstruction/classify_extract_features.cpp
@@ -40,6 +40,7 @@ void ProgExtractFeatures::readParams()
     noDenoising = checkParam("--noDenoising");
     useLBP = checkParam("--lbp");
     useEntropy = checkParam("--entropy");
+    useVariance = checkParam("--variance");
     useZernike = checkParam("--zernike");
 }
 
@@ -54,6 +55,7 @@ void ProgExtractFeatures::show()
     << "Turn off denoising:        " << noDenoising  << std::endl
     << "Extract LBP features:      " << useLBP       << std::endl
     << "Extract entropy features:  " << useEntropy   << std::endl
+    << "Extract variance features: " << useVariance  << std::endl
     << "Extract Zernike moments:   " << useZernike   << std::endl
     ;
 }
@@ -67,6 +69,7 @@ void ProgExtractFeatures::defineParams()
     addParamsLine("  [--noDenoising]               : Turn off denoising");
     addParamsLine("  [--lbp]                       : Extract LBP features");
     addParamsLine("  [--entropy]                   : Extract entropy features");
+    addParamsLine("  [--variance]                  : Extract variance features");
     addParamsLine("  [--zernike]                   : Extract Zernike moments");
 }
 
@@ -223,6 +226,64 @@ void ProgExtractFeatures::extractEntropy(const MultidimArray<double> &I,
     }
 }
 
+void ProgExtractFeatures::extractVariance(const MultidimArray<double> &I,
+                                          std::vector<double> &fv)
+{
+    double var_i_sum = 0.0;
+    double var_o_sum = 0.0;
+    for (int yy = 1; yy <= 4; yy++)
+    {
+        int y_max = YSIZE(I) / 4 * yy;
+        int y_min = YSIZE(I) / 4 * (yy-1);
+        for (int xx = 1; xx <= 4; xx++)
+        {
+            int x_max = XSIZE(I) / 4 * xx;
+            int x_min = XSIZE(I) / 4 * (xx-1);
+
+            double mean = 0.0;
+            int count = 0;
+            double var_i = 0.0;
+            double var_o = 0.0;
+
+            for (int y = y_min; y < y_max; y++)
+            {
+                for (int x = x_min; x < x_max; x++)
+                {
+                    mean += DIRECT_A2D_ELEM(I,y,x);
+                    count++;
+                }
+            }
+            mean = mean / count;
+
+            for (int y = y_min; y < y_max; y++)
+            {
+                for (int x = x_min; x < x_max; x++)
+                {
+                    if (yy > 1 && yy < 4 && xx > 1 && xx < 4)
+                        var_i += (DIRECT_A2D_ELEM(I,y,x) - mean) *
+                                 (DIRECT_A2D_ELEM(I,y,x) - mean);
+                    else
+                        var_o += (DIRECT_A2D_ELEM(I,y,x) - mean) *
+                                 (DIRECT_A2D_ELEM(I,y,x) - mean);
+                }
+            }
+
+            if (yy > 1 && yy < 4 && xx > 1 && xx < 4)
+            {
+                var_i_sum += var_i / count;
+                fv.push_back(var_i / count);
+            }
+            else
+            {
+                var_o_sum += var_o / count;
+                fv.push_back(var_o / count);
+            }
+        }
+    }
+
+    fv.push_back((var_i_sum / 4) / (var_o_sum / 12));
+}
+
 
 void ProgExtractFeatures::extractZernike(const MultidimArray<double> &I,
                                          std::vector<double> &fv)
@@ -319,6 +380,13 @@ void ProgExtractFeatures::run()
         {
             extractEntropy(I(), Imasked(), fv);
             SF.setValue(MDL_SCORE_BY_ENTROPY, fv, __iter.objId);
+            fv.clear();
+        }
+
+        if (useVariance)
+        {
+            extractVariance(I(), fv);
+            SF.setValue(MDL_SCORE_BY_VARIANCE, fv, __iter.objId);
             fv.clear();
         }
 

--- a/software/em/xmipp/libraries/reconstruction/classify_extract_features.h
+++ b/software/em/xmipp/libraries/reconstruction/classify_extract_features.h
@@ -47,6 +47,9 @@ public:
     /**  Parameter for using entropy features */
     bool useEntropy;
 
+    /**  Parameter for using variance features */
+    bool useVariance;
+
     /**  Parameter for using Zernike moments */
     bool useZernike;
 
@@ -72,6 +75,9 @@ public:
 
     /// Extracting entropy features
     void extractEntropy(const MultidimArray<double> &I, MultidimArray<double> &Imasked, std::vector<double> &fv);
+
+    /// Extracting variance features
+    void extractVariance(const MultidimArray<double> &I, std::vector<double> &fv);
 
     /// Extracting Zernike moments
     /// See method at A. Tahmasbi, F. Saki, S. B. Shokouhi, Classification

--- a/software/em/xmipp/libraries/reconstruction/evaluate_coordinates.cpp
+++ b/software/em/xmipp/libraries/reconstruction/evaluate_coordinates.cpp
@@ -54,10 +54,10 @@ void ProgEvaluateCoordinates::show()
 void ProgEvaluateCoordinates::defineParams()
 {
     addUsageLine("Evaluates the set of coordinates against the ground truth");
-    addParamsLine("  -g <selfile>     : Selfile containing ground truth coordinates");
-    addParamsLine("  -e <selfile>     : Selfile containing coordinates to evaluate");
-    addParamsLine("  -n <int>         : Number of micrographs");
-    addParamsLine("  [-t <int=10>]    : Tolerance of center misplacement");
+    addParamsLine("  -g <selfile>      : Selfile containing ground truth coordinates");
+    addParamsLine("  -e <selfile>      : Selfile containing coordinates to evaluate");
+    addParamsLine("  -n <int>          : Number of micrographs");
+    addParamsLine("  [-t <int=10>]     : Tolerance of center misplacement");
     addParamsLine("  --root <rootName> : Root name of the micrographs");
 }
 
@@ -71,8 +71,8 @@ void ProgEvaluateCoordinates::run()
     {
         // Here you need to change the identifiers based on datasets
         // TODO: loading names and counts of mics automatically?
-        FileName micGT = formatString("%s_%04d@%s", rootName, m, fnGt.c_str());
-        FileName micEval = formatString("%s_%04d@%s", rootName, m, fnEval.c_str());
+        FileName micGT = formatString("%s_%04d@%s", rootName.c_str(), m, fnGt.c_str());
+        FileName micEval = formatString("%s_%04d@%s", rootName.c_str(), m, fnEval.c_str());
 
         GT.read(micGT);
         Eval.read(micEval);


### PR DESCRIPTION
Added variance features to xmipp_classify_extract_features
- feature vector consists of 17 values: 16 variance feature values (for 4x4 regions of a single particle) + 1 feature value as their combination that is used for eliminating false positives or the bad particles