### PR TITLE
fixing #1254 (reconstruct_fourier_accel does not compile with gcc7)

### DIFF
--- a/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
+++ b/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
@@ -267,8 +267,7 @@ Array2D<std::complex<float> >* ProgRecFourierAccel::cropAndShift(MultidimArray<s
 				}
 				// do the shift
 				int myPadI = (i < halfY) ?	i + sizeX : i - paddedFourier.ydim + sizeX;
-				(*result)(j, myPadI).real() =	paddedFourierTmp.real();
-				(*result)(j, myPadI).imag() =	paddedFourierTmp.imag();
+				(*result)(j, myPadI) = std::complex<float>(paddedFourierTmp.real(), paddedFourierTmp.imag());
 			}
 		}
 	}


### PR DESCRIPTION
Due to inconsistency in header files, it was not possible to compile code with GCC 7.