### PR TITLE
Release 1.1.facilities mc2

### DIFF
--- a/install/script.py
+++ b/install/script.py
@@ -477,6 +477,9 @@ env.addPackage('motioncor2', version='17.01.30',
 env.addPackage('motioncor2', version='1.0.0',
                tar='motioncor2_1.0.0.tgz')
 
+env.addPackage('motioncor2', version='1.0.1',
+               tar='motioncor2-1.0.1.tgz')
+
 env.addPackage('simple', version='2.1',
                tar='simple2.tgz')
 

--- a/install/script.py
+++ b/install/script.py
@@ -465,20 +465,14 @@ env.addPackage('spider', version='21.13',
 env.addPackage('motioncorr', version='2.1',
                tar='motioncorr_v2.1.tgz')
 
-env.addPackage('motioncor2', version='16.03.16',
-               tar='motioncor2_03162016.tgz')
-
-env.addPackage('motioncor2', version='16.10.19',
-               tar='motioncor2_10192016.tgz')
-
 env.addPackage('motioncor2', version='17.01.30',
                tar='motioncor2_01302017.tgz')
 
 env.addPackage('motioncor2', version='1.0.0',
                tar='motioncor2_1.0.0.tgz')
 
-env.addPackage('motioncor2', version='1.0.1',
-               tar='motioncor2-1.0.1.tgz')
+env.addPackage('motioncor2', version='1.0.2',
+               tar='motioncor2-1.0.2.tgz')
 
 env.addPackage('simple', version='2.1',
                tar='simple2.tgz')

--- a/pyworkflow/em/convert.py
+++ b/pyworkflow/em/convert.py
@@ -185,8 +185,9 @@ class ImageHandler(object):
         over the whole stack. If the input format is ".dm4" or  ".img" only is
         allowed the conversion of the whole stack.
         """
-        if (inputFn.lower().endswith('.dm4') or
-            outputFn.lower().endswith('.img')):
+        inputLower = inputFn.lower()
+        outputLower = outputFn.lower()
+        if inputLower.endswith('.dm4') or outputLower.endswith('.img'):
             if (firstImg and lastImg) is None:
                 # FIXME Since now we can not read dm4 format in Scipion natively
                 # or writing recent .img format
@@ -197,6 +198,14 @@ class ImageHandler(object):
                 ext = os.path.splitext(outputFn)[1]
                 raise Exception("if convert from %s, firstImg and lastImg "
                                 "must be None" % ext)
+        # elif inputLower.endswith('.tif'):
+        #     # FIXME: It seems that we have some flip problem with compressed
+        #     # tif files, we need to check that
+        #     if outputLower.endswith('.mrc'):
+        #         self.runJob('tif2mrc', '%s %s' % (inputFn, outputFn))
+        #     else:
+        #         raise Exception("Conversion from tif to %s is not "
+        #                         "implemented yet. " % pwutils.getExt(outputFn))
         else:
             # get input dim
             (x, y, z, n) = xmipp.getImageSize(inputFn)

--- a/pyworkflow/em/packages/motioncorr/convert.py
+++ b/pyworkflow/em/packages/motioncorr/convert.py
@@ -93,8 +93,7 @@ def getSupportedVersions(var):
     if var == 'MOTIONCORR':
         return ['2.1']
     elif var == 'MOTIONCOR2':
-        return ['03162016', '10192016', '01302017',
-                '1.0.0', '1.0.1']
+        return ['01302017', '1.0.0', '1.0.2']
 
 
 def parseMovieAlignment(logFile):

--- a/pyworkflow/em/packages/motioncorr/convert.py
+++ b/pyworkflow/em/packages/motioncorr/convert.py
@@ -93,7 +93,8 @@ def getSupportedVersions(var):
     if var == 'MOTIONCORR':
         return ['2.1']
     elif var == 'MOTIONCOR2':
-        return ['03162016', '10192016', '01302017', '1.0.0']
+        return ['03162016', '10192016', '01302017',
+                '1.0.0', '1.0.1']
 
 
 def parseMovieAlignment(logFile):

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -136,7 +136,7 @@ class ProtMotionCorr(ProtAlignMovies):
                                     """)
 
         form.addSection(label="Motioncor2")
-        form.addParam('useMotioncor2', params.BooleanParam, default=False,
+        form.addParam('useMotioncor2', params.BooleanParam, default=True,
                       label='Use motioncor2',
                       help='Use new *motioncor2* program with local '
                            'patch-based motion correction and dose weighting.')

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -73,6 +73,12 @@ class ProtMotionCorr(ProtAlignMovies):
     def isLatestVersion(self):
         return getVersion('MOTIONCOR2') == '1.0.1'
 
+    def _getConvertExtension(self, filename):
+        """ Check wether it is needed to convert to .mrc or not """
+        ext = pwutils.getExt(filename).lower()
+        print "_getConvertExtension: ", ext
+        return None if ext in ['.mrc', '.mrcs', '.tiff', '.tif'] else 'mrc'
+
     #--------------------------- DEFINE param functions ------------------------
     def _defineAlignmentParams(self, form):
         form.addParam('gpuMsg', params.LabelParam, default=True,
@@ -370,7 +376,15 @@ class ProtMotionCorr(ProtAlignMovies):
                                                               self.scaleMin,
                                                               self.angDist)
 
-            args = ' -InMrc "%s" ' % movie.getBaseName()
+            ext = pwutils.getExt(movie.getFileName()).lower()
+
+            if ext in ['.mrc', '.mrcs']:
+                args = ' -InMrc "%s" ' % movie.getBaseName()
+            elif ext in ['.tif', '.tiff']:
+                args = ' -InTiff "%s" ' % movie.getBaseName()
+            else:
+                raise Exception("Unsupported format: %s" % ext)
+
             args += ' '.join(['%s %s' % (k, v) for k, v in argsDict.iteritems()])
 
             if inputMovies.getGain():

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -228,7 +228,8 @@ class ProtMotionCorr(ProtAlignMovies):
                                'coordinates, width, and height, respectively.')
 
         form.addParam('extraParams2', params.StringParam, default='',
-                      expertLevel=cons.LEVEL_ADVANCED, condition='useMotioncor2',
+                      expertLevel=cons.LEVEL_ADVANCED,
+                      condition='useMotioncor2',
                       label='Additional parameters',
                       help="""Extra parameters for motioncor2\n
         -Bft       100        BFactor for alignment, in px^2.
@@ -260,7 +261,7 @@ class ProtMotionCorr(ProtAlignMovies):
         # Since only runs on GPU, do not allow neither threads nor mpi
         form.addParallelSection(threads=1, mpi=1)
 
-    #--------------------------- STEPS functions -------------------------------
+    # --------------------------- STEPS functions -------------------------------
     def _processMovie(self, movie):
         inputMovies = self.inputMovies.get()
         movieFolder = self._getOutputMovieFolder(movie)
@@ -269,7 +270,7 @@ class ProtMotionCorr(ProtAlignMovies):
         outputMovieFn = self._getRelPath(self._getOutputMovieName(movie),
                                          movieFolder)
         movieBaseName = pwutils.removeExt(movie.getFileName())
-        aveMicFn =  movieBaseName + '_uncorrected_avg.mrc'
+        aveMicFn = movieBaseName + '_uncorrected_avg.mrc'
         logFile = self._getRelPath(self._getMovieLogFile(movie),
                                    movieFolder)
 
@@ -294,7 +295,8 @@ class ProtMotionCorr(ProtAlignMovies):
                         }
 
             args = '"%s" ' % movie.getBaseName()
-            args += ' '.join(['%s %s' % (k, v) for k, v in argsDict.iteritems()])
+            args += ' '.join(
+                ['%s %s' % (k, v) for k, v in argsDict.iteritems()])
 
             if inputMovies.getGain():
                 args += ' -fgr "%s"' % inputMovies.getGain()
@@ -362,15 +364,17 @@ class ProtMotionCorr(ProtAlignMovies):
                         input_params = parseMagCorrInput(inputEst)
                         # this version uses stretch parameters as following:
                         # 1/maj, 1/min, -angle
-                        argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (1.0 / input_params[1],
-                                                                  1.0 / input_params[2],
-                                                                  -1 * input_params[0])
+                        argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (
+                            1.0 / input_params[1],
+                            1.0 / input_params[2],
+                            -1 * input_params[0])
                     else:
                         # While motioncor2 >=1.0.0 uses estimation params AS IS
                         input_params = parseMagEstOutput(inputEst)
-                        argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (input_params[1],
-                                                                  input_params[2],
-                                                                  input_params[0])
+                        argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (
+                            input_params[1],
+                            input_params[2],
+                            input_params[0])
                 else:
                     argsDict['-Mag'] = '%0.3f %0.3f %0.3f' % (self.scaleMaj,
                                                               self.scaleMin,
@@ -385,7 +389,8 @@ class ProtMotionCorr(ProtAlignMovies):
             else:
                 raise Exception("Unsupported format: %s" % ext)
 
-            args += ' '.join(['%s %s' % (k, v) for k, v in argsDict.iteritems()])
+            args += ' '.join(['%s %s' % (k, v)
+                              for k, v in argsDict.iteritems()])
 
             if inputMovies.getGain():
                 args += ' -Gain "%s" ' % inputMovies.getGain()
@@ -421,11 +426,12 @@ class ProtMotionCorr(ProtAlignMovies):
 
             if self._doComputeMicThumbnail():
                 self.computeThumbnail(outMicFn,
-                                      outputFn=self._getOutputMicThumbnail(movie))
+                                      outputFn=self._getOutputMicThumbnail(
+                                          movie))
         except:
             print("ERROR: Movie %s failed\n" % movie.getName())
 
-    #--------------------------- INFO functions --------------------------------
+    # --------------------------- INFO functions --------------------------------
     def _summary(self):
         summary = []
         return summary
@@ -443,7 +449,7 @@ class ProtMotionCorr(ProtAlignMovies):
         cudaLib = getCudaLib(useMC2=self.useMotioncor2)
         cudaConst = (MOTIONCOR2_CUDA_LIB if self.useMotioncor2 else
                      MOTIONCORR_CUDA_LIB)
-        
+
         if cudaLib is None:
             errors.append("Do not know where to find CUDA lib path. "
                           " %s or %s variables have None value or are not"
@@ -497,7 +503,7 @@ class ProtMotionCorr(ProtAlignMovies):
 
         return errors
 
-    #--------------------------- UTILS functions ------------------------------
+    # --------------------------- UTILS functions ------------------------------
     def _getMovieLogFile(self, movie):
         if not self.useMotioncor2:
             return 'micrograph_%06d_Log.txt' % movie.getObjId()
@@ -550,7 +556,8 @@ class ProtMotionCorr(ProtAlignMovies):
             mic.psdCorr = em.Image(location=self._getPsdCorr(movie))
             mic.psdJpeg = em.Image(location=self._getPsdJpeg(movie))
         if self._doComputeMicThumbnail():
-            mic.thumbnail = em.Image(location=self._getOutputMicThumbnail(movie))
+            mic.thumbnail = em.Image(
+                location=self._getOutputMicThumbnail(movie))
 
     def _saveAlignmentPlots(self, movie):
         """ Compute alignment shift plots and save to file as png images. """
@@ -631,7 +638,7 @@ class ProtMotionCorr(ProtAlignMovies):
 
     def _doComputeMicThumbnail(self):
         return (self.doSaveAveMic and self.doComputeMicThumbnail)
-    
+
     def _supportsMagCorrection(self):
         return getVersion('MOTIONCOR2') not in ['03162016', '10192016']
 
@@ -660,7 +667,7 @@ def createGlobalAlignmentPlot(meanX, meanY, first):
         preY += y
         sumMeanX.append(preX)
         sumMeanY.append(preY)
-        ax.text(preX-0.02, preY+0.02, str(i))
+        ax.text(preX - 0.02, preY + 0.02, str(i))
         i += 1
 
     ax.plot(sumMeanX, sumMeanY, color='b')

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -71,7 +71,7 @@ class ProtMotionCorr(ProtAlignMovies):
         return getVersion('MOTIONCOR2').startswith('1.0.')
 
     def isLatestVersion(self):
-        return getVersion('MOTIONCOR2') == '1.0.1'
+        return getVersion('MOTIONCOR2') == '1.0.2'
 
     def _getConvertExtension(self, filename):
         """ Check wether it is needed to convert to .mrc or not """
@@ -351,7 +351,7 @@ class ProtMotionCorr(ProtAlignMovies):
                 if self.defectFile.get():
                     argsDict['-DefectFile'] = self.defectFile.get()
 
-                # Currently only version 1.0.1
+                # From version 1.0.1
                 if self.isLatestVersion():
                     patchOverlap = self.getAttributeValue('patchOverlap', None)
                     if patchOverlap: # 0 or None is False

--- a/pyworkflow/tests/em/protocols/test_protocols_motioncorr.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_motioncorr.py
@@ -96,7 +96,8 @@ class TestMotioncorrAlignMovies(BaseTest):
 
     def test_qbeta(self):
         prot = self.newProtocol(ProtMotionCorr,
-                                objLabel='qbeta - motioncorr test1')
+                                objLabel='qbeta - motioncorr test1',
+                                useMotioncor2=False,)
         prot.inputMovies.set(self.protImport1.outputMovies)
         self.launchProtocol(prot)
 
@@ -109,6 +110,7 @@ class TestMotioncorrAlignMovies(BaseTest):
     def test_cct(self):
         prot = self.newProtocol(ProtMotionCorr,
                                 objLabel='cct - motioncorr test',
+                                useMotioncor2=False,
                                 doSaveMovie=True)
         prot.inputMovies.set(self.protImport2.outputMovies)
         self.launchProtocol(prot)
@@ -121,6 +123,7 @@ class TestMotioncorrAlignMovies(BaseTest):
     def test_qbeta_SkipCrop(self):
         prot = self.newProtocol(ProtMotionCorr,
                                 objLabel='qbeta - motioncorr test2',
+                                useMotioncor2=False,
                                 alignFrame0=3, alignFrameN=5,
                                 cropOffsetX=10, cropOffsetY=10)
         prot.inputMovies.set(self.protImport1.outputMovies)


### PR DESCRIPTION
Changes in this PR:

* Updated version of motioncor2-1.0.1
* Removed conversion from tif for motioncor2

Slightly more general way to express that input movies need to be converted to a given format.