### PR TITLE
Don't use realpath when searching for mpi.

### DIFF
--- a/pyworkflow/apps/pw_config.py
+++ b/pyworkflow/apps/pw_config.py
@@ -433,7 +433,7 @@ def guessMPI():
     for d in os.environ.get('PATH', '').split(':'):
         if not os.path.isdir(d) or 'mpicc' not in os.listdir(d):
             continue
-        mpiBin = os.path.realpath(join(d, 'mpicc'))
+        mpiBin = join(d, 'mpicc')
         if 'MPI_BINDIR' not in options:
             options['MPI_BINDIR'] = os.path.dirname(mpiBin)
         if mpiBin.endswith('/bin/mpicc'):


### PR DESCRIPTION
OpenMPIs mpicc is a softlink to orted and the rest of the code will not
find the correct mpiHome.