### PR TITLE
fixing build with old compilers

### DIFF
--- a/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
+++ b/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.cpp
@@ -135,6 +135,7 @@ void ProgRecFourierAccel::run()
 
 void ProgRecFourierAccel::createLoadingThread() {
 	barrier_init( &barrier, 2 ); // two barries - for main and loading thread
+	loadThread.buffer1 = loadThread.buffer2 = NULL;
 	loadThread.parent = this;
 	loadThread.selFile = &SF;
 	pthread_create( &loadThread.id , NULL, loadImageThread, (void *)(&loadThread) );

--- a/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
+++ b/software/em/xmipp/libraries/reconstruction/reconstruct_fourier_accel.h
@@ -104,13 +104,14 @@ struct LoadThreadParams
     int startImageIndex;
     int endImageIndex;
     MetaData* selFile;
-    ProjectionData* buffer1 = NULL;
-    ProjectionData* buffer2 = NULL;
+    ProjectionData* buffer1;
+    ProjectionData* buffer2;
 };
 
 class ProgRecFourierAccel : public ProgReconsBase
 {
 public:
+	ProgRecFourierAccel() : tempVolume(NULL), tempWeights(NULL) {};
     /**
      * Run the image processing.
      * Method will load data, process them and store result to final destination.
@@ -154,13 +155,13 @@ protected:
 	 * Lowest frequencies are in the center, i.e. Fourier space creates a
 	 * sphere within a cube.
 	 */
-	std::complex<float>*** tempVolume = NULL;
+	std::complex<float>*** tempVolume;
 
 	/**
 	 * 3D volume holding the weights of the Fourier coefficients stored
 	 * in tempVolume.
 	 */
-	float*** tempWeights = NULL;
+	float*** tempWeights;
 
 	/**
 	 * Method will take temp spaces (containing complex conjugate values


### PR DESCRIPTION
This fix aim e.g.  gcc (GCC) 4.4.7 20120313 (Red Hat 4.4.7-18) and on CentOS 6.9, where current code cannot be build (error: ISO C++ forbids initialization of member 'buffer1').