### PR TITLE
Fixed bug in Relion extract - particles and PatchOverlap hidden when not MC2

### DIFF
--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -172,6 +172,7 @@ class ProtMotionCorr(ProtAlignMovies):
 
         if self.versionGE('1.0.1'): # Patch overlap was introduced in 1.0.1
             form.addParam('patchOverlap', params.IntParam, default=0,
+                          condition='useMotioncor2',
                           label='Patches Overlap (%)',
                           help='In versions > 1.0.1 it is possible to specify'
                                  'the overlapping between patches. '

--- a/pyworkflow/em/packages/relion/protocol_extract_particles.py
+++ b/pyworkflow/em/packages/relion/protocol_extract_particles.py
@@ -561,10 +561,9 @@ class ProtRelionExtractParticles(em.ProtExtractParticles, ProtRelionBase):
         # The command will be launched from the working dir
         # so, let's make the micrograph path relative to that
         img.setFileName(os.path.join('extra', newName))
-        if self._useCTF() and not img.hasCTF():
-            img.setCTF(self.ctfDict[img.getMicName()])
 
         if self._useCTF():
+            img.setCTF(self.ctfDict[img.getMicName()])
             # add phaseShift to micrograph Row
             ctf = img.getCTF()
             if ctf is not None and ctf.getPhaseShift():


### PR DESCRIPTION
@josuegbl I think there was a condition introduced by you (img.hasCTF()) that was causing all rows in the star file had the same defocus values. I just removed it and now seems to work as expected, can you double-check the changes?