### PR TITLE
fixed software/em/xmipp/libraries/data/image_resize.cpp to run with m…

### DIFF
--- a/software/em/xmipp/libraries/data/image_resize.cpp
+++ b/software/em/xmipp/libraries/data/image_resize.cpp
@@ -96,6 +96,7 @@ void ProgImageResize::preProcess()
         fn_out=fn_in+"_tmp";
         fn_out=fn_out.addExtension(fn_in.getExtension());
         temporaryOutput=true;
+        create_empty_stackfile=true;
     }
 
     if (checkParam("--factor") || checkParam("--dim"))


### PR DESCRIPTION
There were a bug in crop/resize due to xmipp_image_resize_program when running mpi. Now creates first empty file for all particles. Test checking will be needed