### PR TITLE
Trigger data - remove unused functions

### DIFF
--- a/pyworkflow/em/packages/xmipp3/protocol_eliminate_empty_particles.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_eliminate_empty_particles.py
@@ -129,7 +129,9 @@ class XmippProtEliminateEmptyParticles(ProtClassify2D):
             writeSetOfParticles(self.partsSet, fnInputMd,
                                 alignType=em.ALIGN_NONE, orderBy='creation',
                                 where='creation>"' + str(self.check) + '"')
-        self.check = self.partsSet[len(self.partsSet) - 1].getObjCreation()
+        for p in self.partsSet.iterItems(orderBy='creation', direction='DESC'):
+            self.check = p.getObjCreation()
+            break
         args = "-i %s -o %s -e %s -t %f" % (
         fnInputMd, self.fnOutputMd, self.fnElimMd, self.threshold.get())
         if self.addFeatures:

--- a/pyworkflow/em/packages/xmipp3/protocol_eliminate_empty_particles.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_eliminate_empty_particles.py
@@ -132,6 +132,7 @@ class XmippProtEliminateEmptyParticles(ProtClassify2D):
         for p in self.partsSet.iterItems(orderBy='creation', direction='DESC'):
             self.check = p.getObjCreation()
             break
+        self.partsSet.close()
         args = "-i %s -o %s -e %s -t %f" % (
         fnInputMd, self.fnOutputMd, self.fnElimMd, self.threshold.get())
         if self.addFeatures:

--- a/pyworkflow/em/packages/xmipp3/protocol_trigger_data.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_trigger_data.py
@@ -112,7 +112,10 @@ class XmippProtTriggerData(ProtProcessParticles):
 
         self.particles = self.particles + self.newParticles
         if len(self.newParticles) > 0:
-            self.check = self.partsSet[len(self.particles)-1].getObjCreation()
+            for p in self.partsSet.iterItems(orderBy='creation',
+                                             direction='DESC'):
+                self.check = p.getObjCreation()
+                break
 
         self.lastCheck = datetime.now()
         self.streamClosed = self.partsSet.isStreamClosed()

--- a/pyworkflow/em/packages/xmipp3/protocol_trigger_data.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_trigger_data.py
@@ -199,23 +199,3 @@ class XmippProtTriggerData(ProtProcessParticles):
 
     def _validate(self):
         pass
-
-    # --------------------------- UTILS functions -----------------------------
-    def _readDoneList(self):
-        """ Read from a file the id's of the items that have been done. """
-        doneFile = self._getAllDone()
-        doneList = []
-        # Check what items have been previously done
-        if os.path.exists(doneFile):
-            with open(doneFile) as f:
-                doneList += [int(line.strip()) for line in f]
-        return doneList
-
-    def _getAllDone(self):
-        return self._getExtraPath('DONE_all.TXT')
-
-    def _writeDoneList(self, partList):
-        """ Write to a file the items that have been done. """
-        with open(self._getAllDone(), 'a') as f:
-            for part in partList:
-                f.write('%d\n' % part.getObjId())


### PR DESCRIPTION
Removing unused functions from protocol_trigger_data.py
Added small fix when particle IDs are not sequential (also for eliminate empty particles) 