### PR TITLE
incorporate workflow repository to python

### DIFF
--- a/install/script.py
+++ b/install/script.py
@@ -301,6 +301,7 @@ env.addPipModule('setuptools', '38.2.5')
 numpy = env.addPipModule('numpy','1.14.1')
 matplotlib = env.addPipModule('matplotlib', '1.5.3', target='matplotlib-1.5.3*')
 env.addPipModule('psutil', '2.1.1', target='psutil-2.1.1*')
+env.addPipModule('poster', '0.8.1', target='poster-0.8.1*')
 env.addPipModule('mpi4py', '1.3.1')
 scipy = env.addPipModule('scipy', '0.14.0',
                      default=not noScipy, deps=[lapack, matplotlib])

--- a/pyworkflow/em/protocol/protocol_import/volumes.py
+++ b/pyworkflow/em/protocol/protocol_import/volumes.py
@@ -127,7 +127,6 @@ class ProtImportVolumes(ProtImportImages):
         volSet.setSamplingRate(samplingRate)
 
         for fileName, fileId in self.iterFiles():
-            newFileName = abspath(self._getVolumeFileName(fileName))
             x, y, z, n = imgh.getDimensions(fileName)
             if fileName.endswith('.mrc') or fileName.endswith('.map'):
                 fileName += ':mrc'
@@ -136,6 +135,8 @@ class ProtImportVolumes(ProtImportImages):
                     n = 1
                 else:
                     zDim = z
+            else:
+                zDim = z
             origin = Transform()
             if setOrigCoord:
                 origin.setShiftsTuple(self._getOrigCoord())
@@ -147,10 +148,13 @@ class ProtImportVolumes(ProtImportImages):
             vol.setOrigin(origin)  # read origin from form
 
             if self.copyFiles or setOrigCoord:
+                newFileName = abspath(self._getVolumeFileName(fileName, "mrc"))
                 adaptFileToCCP4(fileName, newFileName, origin.getShifts(),
                                 samplingRate,
                                 ORIGIN)
             else:
+                newFileName = abspath(self._getVolumeFileName(fileName))
+
                 if fileName.endswith(':mrc'):
                     fileName = fileName[:-4]
                 createAbsLink(fileName, newFileName)
@@ -197,8 +201,12 @@ class ProtImportVolumes(ProtImportImages):
                            (self._getVolMessage(), self.samplingRate.get()),)
         return methods
 
-    def _getVolumeFileName(self, fileName):
-        baseFileName="import_" + basename(fileName).split(".")[0] + ".mrc"
+    def _getVolumeFileName(self, fileName, extension=None):
+        if extension is not None: 
+            baseFileName="import_" + basename(fileName).split(".")[0] + ".%s"%extension
+        else:
+            baseFileName="import_" + basename(fileName)
+
         return self._getExtraPath(baseFileName)
 
     def _getOrigCoord(self):

--- a/pyworkflow/em/protocol/protocol_import/volumes.py
+++ b/pyworkflow/em/protocol/protocol_import/volumes.py
@@ -205,7 +205,7 @@ class ProtImportVolumes(ProtImportImages):
         if extension is not None: 
             baseFileName="import_" + basename(fileName).split(".")[0] + ".%s"%extension
         else:
-            baseFileName="import_" + basename(fileName)
+            baseFileName="import_" + basename(fileName).split(":")[0]
 
         return self._getExtraPath(baseFileName)
 

--- a/pyworkflow/gui/project/constants.py
+++ b/pyworkflow/gui/project/constants.py
@@ -41,6 +41,7 @@ STATUS_COLORS = {
                STATUS_SCHEDULED: '#F3F5CB'
                }
 
+#WORKFLOW_REPOSITORY_SERVER='https://warm-sea-81539.herokuapp.com/'
 WORKFLOW_REPOSITORY_SERVER='http://127.0.0.1:8000/'
 WORKFLOW_PROG_STEP1='workflowProgStep1_add/'
 WORKFLOW_PROG_STEP2='workflowProgStep2_add/'

--- a/pyworkflow/gui/project/constants.py
+++ b/pyworkflow/gui/project/constants.py
@@ -41,3 +41,6 @@ STATUS_COLORS = {
                STATUS_SCHEDULED: '#F3F5CB'
                }
 
+WORKFLOW_REPOSITORY_SERVER='http://127.0.0.1:8000/'
+WORKFLOW_PROG_STEP1='workflowProgStep1_add/'
+WORKFLOW_PROG_STEP2='workflowProgStep2_add/'

--- a/pyworkflow/gui/project/constants.py
+++ b/pyworkflow/gui/project/constants.py
@@ -41,7 +41,8 @@ STATUS_COLORS = {
                STATUS_SCHEDULED: '#F3F5CB'
                }
 
-#WORKFLOW_REPOSITORY_SERVER='https://warm-sea-81539.herokuapp.com/'
-WORKFLOW_REPOSITORY_SERVER='http://127.0.0.1:8000/'
+#WORKFLOW_REPOSITORY_SERVER='https://workflows.scipion.i2pc.es/'
+WORKFLOW_REPOSITORY_SERVER='https://warm-sea-81539.herokuapp.com/'
+#WORKFLOW_REPOSITORY_SERVER='http://127.0.0.1:8000/'
 WORKFLOW_PROG_STEP1='workflowProgStep1_add/'
 WORKFLOW_PROG_STEP2='workflowProgStep2_add/'

--- a/pyworkflow/gui/project/constants.py
+++ b/pyworkflow/gui/project/constants.py
@@ -41,8 +41,8 @@ STATUS_COLORS = {
                STATUS_SCHEDULED: '#F3F5CB'
                }
 
-#WORKFLOW_REPOSITORY_SERVER='https://workflows.scipion.i2pc.es/'
-WORKFLOW_REPOSITORY_SERVER='https://warm-sea-81539.herokuapp.com/'
+WORKFLOW_REPOSITORY_SERVER='http://workflows.scipion.i2pc.es/'
+#WORKFLOW_REPOSITORY_SERVER='https://warm-sea-81539.herokuapp.com/'
 #WORKFLOW_REPOSITORY_SERVER='http://127.0.0.1:8000/'
 WORKFLOW_PROG_STEP1='workflowProgStep1_add/'
 WORKFLOW_PROG_STEP2='workflowProgStep2_add/'

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -55,6 +55,7 @@ from labels import LabelsDialog
 
 # Import possible Object commands to be handled
 from base import ProjectBaseWindow, VIEW_PROTOCOLS, VIEW_PROJECTS
+from constants import WORKFLOW_REPOSITORY_SERVER
 
 
 
@@ -224,7 +225,7 @@ class ProjectWindow(ProjectBaseWindow):
             self.showError(str(ex))
 
     def onSearchWorkflow(self):
-        search_url='http://127.0.0.1:8000'
+        search_url = WORKFLOW_REPOSITORY_SERVER
         webbrowser.open(search_url)
 
     def onImportWorkflow(self):

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -96,7 +96,7 @@ class ProjectWindow(ProjectBaseWindow):
         projMenu.addSubMenu('Import workflow', 'load_workflow',
                             icon='fa-download.png')
         projMenu.addSubMenu('Search workflow', 'search_workflow',
-                            icon='fa-download.png')
+                            icon='fa-search.png')
         projMenu.addSubMenu('Export tree graph', 'export_tree')
         projMenu.addSubMenu('', '')  # add separator
         projMenu.addSubMenu('Notes', 'notes', icon='fa-pencil.png')

--- a/pyworkflow/gui/project/project.py
+++ b/pyworkflow/gui/project/project.py
@@ -39,7 +39,7 @@ import subprocess
 import uuid
 import SocketServer
 import tempfile
-
+import webbrowser
 import pyworkflow as pw
 import pyworkflow.utils as pwutils
 from pyworkflow.manager import Manager
@@ -93,6 +93,8 @@ class ProjectWindow(ProjectBaseWindow):
                             shortCut="Ctrl+f")
         projMenu.addSubMenu('', '')  # add separator
         projMenu.addSubMenu('Import workflow', 'load_workflow',
+                            icon='fa-download.png')
+        projMenu.addSubMenu('Search workflow', 'search_workflow',
                             icon='fa-download.png')
         projMenu.addSubMenu('Export tree graph', 'export_tree')
         projMenu.addSubMenu('', '')  # add separator
@@ -220,7 +222,11 @@ class ProjectWindow(ProjectBaseWindow):
             self.getViewWidget().updateRunsGraph(True, reorganize=True)
         except Exception, ex:
             self.showError(str(ex))
-            
+
+    def onSearchWorkflow(self):
+        search_url='http://127.0.0.1:8000'
+        webbrowser.open(search_url)
+
     def onImportWorkflow(self):
         FileBrowserWindow("Select workflow .json file",
                           self, self.project.getPath(''),

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -55,6 +55,9 @@ from pyworkflow.utils.properties import Message, Icon, Color, KEYSYM
 
 from constants import STATUS_COLORS
 from pyworkflow.gui.project.utils import getStatusColorFromNode
+import poster.streaminghttp
+import urllib2
+import webbrowser
 
 DEFAULT_BOX_COLOR = '#f8f8f8'
 
@@ -73,6 +76,7 @@ ACTION_DEFAULT = Message.LABEL_DEFAULT
 ACTION_CONTINUE = Message.LABEL_CONTINUE
 ACTION_RESULTS = Message.LABEL_ANALYZE
 ACTION_EXPORT = Message.LABEL_EXPORT
+ACTION_EXPORT_UPLOAD = Message.LABEL_EXPORT_UPLOAD
 ACTION_SWITCH_VIEW = 'Switch_View'
 ACTION_COLLAPSE = 'Collapse'
 ACTION_EXPAND = 'Expand'
@@ -100,6 +104,7 @@ ActionIcons = {
     ACTION_CONTINUE: Icon.ACTION_CONTINUE,
     ACTION_RESULTS: Icon.ACTION_RESULTS,
     ACTION_EXPORT: Icon.ACTION_EXPORT,
+    ACTION_EXPORT_UPLOAD: Icon.ACTION_EXPORT_UPLOAD,
     ACTION_COLLAPSE: 'fa-minus-square.png',
     ACTION_EXPAND: 'fa-plus-square.png',
     ACTION_LABELS: Icon.TAGS
@@ -190,6 +195,7 @@ class RunsTreeProvider(pwgui.tree.ProjectRunsTreeProvider):
                 (ACTION_DB, single),
                 (ACTION_STOP, stoppable and single),
                 (ACTION_EXPORT, not single),
+                (ACTION_EXPORT_UPLOAD, not single),
                 (ACTION_COLLAPSE, single and status and expanded),
                 (ACTION_EXPAND, single and status and not expanded),
                 (ACTION_LABELS, True),
@@ -840,8 +846,8 @@ class ProtocolsView(tk.Frame):
         self.actionList = [ACTION_EDIT, ACTION_COPY, ACTION_DELETE,
                            ACTION_STEPS, ACTION_BROWSE, ACTION_DB,
                            ACTION_STOP, ACTION_CONTINUE, ACTION_RESULTS,
-                           ACTION_EXPORT, ACTION_COLLAPSE, ACTION_EXPAND,
-                           ACTION_LABELS]
+                           ACTION_EXPORT, ACTION_EXPORT_UPLOAD, ACTION_COLLAPSE, 
+                           ACTION_EXPAND, ACTION_LABELS]
         self.actionButtons = {}
 
         def addButton(action, text, toolbar):
@@ -1826,6 +1832,61 @@ class ProtocolsView(tk.Frame):
             entryLabel='File', entryValue='workflow.json')
         browser.show()
 
+    def _exportUploadProtocols(self):
+
+        def uploadWorkflow(upload_file_url, upload_metadata_url, jsonFileName):
+            """ Upload workflow 'jsonFileName'to server upload_file_url
+                First the file is uploaded, then the metadata is uploaded.
+                The script uploads the file and then opens a browser for the metadata
+                Note that the two steps are needed since noinitial value can be passed
+                to a file field. poster module is needed. Poster is pure python
+                so it may be added to the directory rather than installed if needed.
+
+                The server is django a uses filefield and csrf_exempt.
+                csrf_exempt disable csrf checking. filefield
+            """
+            # json file to upload
+            params =  dict(json=open(jsonFileName, 'rb'))
+            # we are going to upload a file so this is a multipart 
+            # connection
+            datagen, headers = poster.encode.multipart_encode(params)
+            opener = poster.streaminghttp.register_openers()
+            # create request and connect to server
+            response = opener.open(urllib2.Request(upload_file_url,
+                                   datagen, headers))
+            # server returns dictionary as json with remote name of the saved file
+            _dict = json.loads(response.read())
+            # server has stored file in file named _dict['jsonFileName']
+            # TODO: This version thing is a horrible hack but it is not
+            # my fault. Scipion does not offer a better way to know the
+            # version
+            import imp
+            currentDir = os.path.dirname(os.path.abspath(__file__))
+            currentFile = os.path.join(currentDir,'../../../scipion')
+            mod = imp.load_source('scipion', currentFile)
+            version = mod.getVersion()
+            # version hack end
+            fileNameUrl = "?jsonFileName=%s&versionInit=%s"%\
+                          (_dict['jsonFileName'], version) # use GET
+            # open browser to fill metadata, fileNAme will be saved as session variable
+            # note that I cannot save the file nave in the session in the first
+            # conection beacause the broeser changes from urlib2 to an actual browser
+            # so sessions are different
+            webbrowser.open(upload_metadata_url+fileNameUrl)
+            #delete temporary file
+            os.remove(jsonFileName) if os.path.exists(jsonFileName) \
+                                    else None
+
+        protocols = self._getSelectedProtocols()
+        jsonFileName = os.path.join(tempfile.mkdtemp(), 'workflow.json')
+        upload_file_url = "http://127.0.0.1:8000/workflowFile_add/"
+        upload_metadata_url = "http://127.0.0.1:8000/workflowModel_add/"
+        try:
+	    self.project.exportProtocols(protocols, jsonFileName)
+            uploadWorkflow(upload_file_url, upload_metadata_url, jsonFileName)
+        except Exception as ex:
+	    self.windows.showError(str(ex))
+
     def _stopProtocol(self, prot):
         if pwgui.dialog.askYesNo(Message.TITLE_STOP_FORM,
                                  Message.LABEL_STOP_FORM, self.root):
@@ -1929,6 +1990,8 @@ class ProtocolsView(tk.Frame):
                     self._analyzeResults(prot)
                 elif action == ACTION_EXPORT:
                     self._exportProtocols()
+                elif action == ACTION_EXPORT_UPLOAD:
+                    self._exportUploadProtocols()
                 elif action == ACTION_COLLAPSE:
                     nodeInfo = self.settings.getNodeById(prot.getObjId())
                     nodeInfo.setExpanded(False)

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -1865,7 +1865,7 @@ class ProtocolsView(tk.Frame):
             currentDir = os.path.dirname(os.path.abspath(__file__))
             currentFile = os.path.join(currentDir,'../../../scipion')
             mod = imp.load_source('scipion', currentFile)
-            version = mod.getVersion()
+            version = mod.getVersion(False)
             # version hack end
             fileNameUrl = "?jsonFileName=%s&versionInit=%s"%\
                           (_dict['jsonFileName'], version) # use GET

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -25,7 +25,8 @@
 # *
 # **************************************************************************
 from __future__ import print_function
-
+from constants import WORKFLOW_REPOSITORY_SERVER, \
+    WORKFLOW_PROG_STEP1, WORKFLOW_PROG_STEP2
 
 INIT_REFRESH_SECONDS = 3
 
@@ -1868,9 +1869,10 @@ class ProtocolsView(tk.Frame):
             # version hack end
             fileNameUrl = "?jsonFileName=%s&versionInit=%s"%\
                           (_dict['jsonFileName'], version) # use GET
-            # open browser to fill metadata, fileNAme will be saved as session variable
-            # note that I cannot save the file nave in the session in the first
-            # conection beacause the broeser changes from urlib2 to an actual browser
+            # open browser to fill metadata, fileNAme will be saved as session
+            # variable. Note that I cannot save the file nave in the
+            # session in the first conection because the browser changes
+            # from urlib2 to an actual browser
             # so sessions are different
             webbrowser.open(upload_metadata_url+fileNameUrl)
             #delete temporary file
@@ -1879,13 +1881,13 @@ class ProtocolsView(tk.Frame):
 
         protocols = self._getSelectedProtocols()
         jsonFileName = os.path.join(tempfile.mkdtemp(), 'workflow.json')
-        upload_file_url = "http://127.0.0.1:8000/workflowFile_add/"
-        upload_metadata_url = "http://127.0.0.1:8000/workflowModel_add/"
+        upload_file_url = WORKFLOW_REPOSITORY_SERVER + WORKFLOW_PROG_STEP1
+        upload_metadata_url = WORKFLOW_REPOSITORY_SERVER + WORKFLOW_PROG_STEP2
         try:
-	    self.project.exportProtocols(protocols, jsonFileName)
+            self.project.exportProtocols(protocols, jsonFileName)
             uploadWorkflow(upload_file_url, upload_metadata_url, jsonFileName)
         except Exception as ex:
-	    self.windows.showError(str(ex))
+            self.windows.showError(str(ex))
 
     def _stopProtocol(self, prot):
         if pwgui.dialog.askYesNo(Message.TITLE_STOP_FORM,

--- a/pyworkflow/utils/properties.py
+++ b/pyworkflow/utils/properties.py
@@ -84,6 +84,7 @@ class Message():
     LABEL_CONTINUE = 'Continue'
     LABEL_CONTINUE_ACTION = 'Approve continue'
     LABEL_EXPORT = 'Export'
+    LABEL_EXPORT_UPLOAD = 'Export & upload'
     
     #-- Tabs --
     LABEL_DATA = 'Data'
@@ -358,6 +359,7 @@ class Icon():
     ACTION_HELP = 'fa-question-circle.png'
     ACTION_REFERENCES = 'fa-external-link.png'
     ACTION_EXPORT = 'fa-external-link.png'
+    ACTION_EXPORT_UPLOAD = 'fa-upload.png'
     
     ACTION_SEARCH = 'fa-search.png'
     ACTION_EXECUTE = 'fa-cogs.png'


### PR DESCRIPTION
This pull request incorporates a few lines of code in Scipion so it can connect to the Scipion Workflow Repository.

The workflow repository is available at URL: http://workflows.scipion.i2pc.es/
There is a help page at: https://github.com/I2PC/scipionWorkflowRepository/wiki/Scipion-Workflow-Repository-Help-Page.

No test has been created since I do not know how to test the tk part of Scipion.

You may start the search GUI from Scipion (select project from the menu and then search workflow) or connect directly to the search URL at http://workflows.scipion.i2pc.es. 

To upload a protocol using Scipion select the protocols (click on them while holding the CTRL-key) and then right click and choose upload workflow from the pop up menu. At this point a browser will be opened, fill the form (all fields are compulsory) and press the create button. Thanks for share your workflows ;-).

---------------

Totally unrelated with the above describe problem I also fix a small bug in volume import protocol when a ·D map is imported but not copied and the 3Dmap format is not mrc/ccp4