### PR TITLE
Need to split on os.pathsep (":") when doing appendUnique of LIBPATH to libPathCopy.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -464,7 +464,7 @@ def addProgram(env, name, src=None, pattern=None, installDir=None,
     cxxflagsCopy = cxxflags + env['CXXFLAGS']
     linkflagsCopy = linkflags + env['LINKFLAGS']
     ldLibraryPathCopy = [env['LIBPATH']]
-    appendUnique(libPathsCopy, env.get('LIBPATH', ''))
+    appendUnique(libPathsCopy, env.get('LIBPATH', '').split(os.pathsep))
     env2 = Environment()
     if mpi: 
         appendUnique(incsCopy, env['MPI_INCLUDE'])


### PR DESCRIPTION
Need to split on os.pathsep (":") when doing appendUnique of LIBPATH to libPathCopy.

Otherwise the end result will be
-Lpath1:path2:path3
instead of
-Lpath1 -Lpath2 -Lpath3.