### PR TITLE
Bug fixing in -gpu argument

### DIFF
--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -340,7 +340,7 @@ class ProtMotionCorr(ProtAlignMovies):
             if self.doSaveMovie:
                 args += ' -fct "%s" -ssc 1' % outputMovieFn
 
-            args += '-gpu %(GPU)s'
+            args += ' -gpu %(GPU)s'
             args += ' ' + self.extraParams.get()
             program = MOTIONCORR_PATH
 


### PR DESCRIPTION
A space before -gpu argument is need it to separate from the previous argument.