### PR TITLE
Tolerate loading project.sqlite when sets are required and improve backward compatibility.

### DIFF
--- a/pyworkflow/em/packages/grigoriefflab/protocol_unblur.py
+++ b/pyworkflow/em/packages/grigoriefflab/protocol_unblur.py
@@ -466,6 +466,7 @@ eof
         first, _ = self._getFrameRange(movie.getNumberOfFrames(), 'align')
         plotter = createGlobalAlignmentPlot(shiftsX, shiftsY, first)
         plotter.savefig(self._getPlotGlobal(movie))
+        plotter.close()
 
 def createGlobalAlignmentPlot(meanX, meanY, first):
     """ Create a plotter with the shift per frame. """

--- a/pyworkflow/em/packages/ispyb/protocol_monitor_ispyb.py
+++ b/pyworkflow/em/packages/ispyb/protocol_monitor_ispyb.py
@@ -232,6 +232,7 @@ def _saveAlignmentPlots(self, movie):
     meanX, meanY = self._loadMeanShifts(movie)
     plotter = createAlignmentPlot(meanX, meanY)
     plotter.savefig(self._getPlotCart(movie))
+    plotter.close()
 
 
 def createAlignmentPlot(meanX, meanY):

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -641,6 +641,7 @@ class ProtMotionCorr(ProtAlignMovies):
         first, _ = self._getFrameRange(movie.getNumberOfFrames(), 'align')
         plotter = createGlobalAlignmentPlot(shiftsX, shiftsY, first)
         plotter.savefig(self._getPlotGlobal(movie))
+        plotter.close()
 
     def _isOutStackSupport(self):
         # checks if output aligned movies can be saved by motioncor2

--- a/pyworkflow/em/packages/resmap/protocol_resmap.py
+++ b/pyworkflow/em/packages/resmap/protocol_resmap.py
@@ -210,10 +210,15 @@ class ProtResMap(ProtAnalysis3D):
         # This is needed right now because we are having
         # some memory problem with matplotlib plots right now in web
         Plotter.setBackend('Agg')
-        self._plotVolumeSlices().savefig(self._getExtraPath('volume1.map.png'))
+        plot = self._plotVolumeSlices()
+        plot.savefig(self._getExtraPath('volume1.map.png'))
+        plot.close()
         plot = self._plotResMapSlices(results['resTOTALma'])
         plot.savefig(self._getExtraPath('volume1_resmap.map.png'))
-        self._plotHistogram().savefig(self._getExtraPath('histogram.png'))
+        plot.close()
+        plot = self._plotHistogram()
+        plot.savefig(self._getExtraPath('histogram.png'))
+        plot.close()
 
     #--------------------------- INFO functions --------------------------------------------
     

--- a/pyworkflow/em/packages/xmipp3/bibtex.py
+++ b/pyworkflow/em/packages/xmipp3/bibtex.py
@@ -560,13 +560,15 @@ keywords = ""
   url                      = "http://dx.doi.org/10.1038/srep14290"
 }
 
-@article{Vilas2017,
-  title                    = {MonoRes: Automatic and unbiased estimation of local resolution for electron microscopy maps.},
+@article{Vilas2018,
+  title                    = {MonoRes: Automatic and Accurate Estimation of Local Resolution for Electron Microscopy Maps},
   author                   = {Vilas, J. L. and et al},
-  year                     = "2017",
+  year                     = "2018",
   journal                  = "Structure",
-  note                     = "submitted",
-  doi                      = {http://github.com/I2PC/scipion/wiki/XmippProtMonoRes}
+  pages                    = "337--344",
+  volume                   = "26",
+  doi = {10.1016/j.str.2017.12.018},
+  url = {https://doi.org/10.1016/j.str.2017.12.018},
 }
 
 

--- a/pyworkflow/em/packages/xmipp3/protocol_movie_correlation.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_movie_correlation.py
@@ -227,6 +227,7 @@ class XmippProtMovieCorr(ProtAlignMovies):
         meanX, meanY = self._loadMeanShifts(movie)
         plotter = createAlignmentPlot(meanX, meanY)
         plotter.savefig(self._getPlotCart(movie))
+        plotter.close()
 
     def _setAlignmentInfo(self, movie, obj):
         """ Set alignment info such as plot and psd filename, and

--- a/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
@@ -351,6 +351,7 @@ class XmippProtOFAlignment(ProtAlignMovies):
         meanX, meanY = self._loadMeanShifts(movie)
         plotter = createAlignmentPlot(meanX, meanY)
         plotter.savefig(self._getPlotCart(movie))
+        plotter.close()
 
     def _createOutputMicrographs(self):
         createWeighted = self._createOutputWeightedMicrographs()

--- a/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
@@ -297,27 +297,7 @@ class XmippProtMonoRes(ProtAnalysis3D):
         freq_step = 1
 
         xdim = self.maskRadius(self.halfVolumes, self.isPremasked)
-#         
-#         if self.halfVolumes:
-#             if self.isPremasked:
-#                 if self.volumeRadiusHalf == -1:
-#                     xdim, _ydim, _zdim = self.inputVolume.get().getDim()
-#                     xdim = xdim*0.5
-#                 else:
-#                     xdim = self.volumeRadiusHalf.get()
-#             else:
-#                 xdim, _ydim, _zdim = self.inputVolume.get().getDim()
-#                 xdim = xdim*0.5
-#         else:
-#             if self.isPremasked:
-#                 if self.volumeRadius == -1:
-#                     xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
-#                     xdim = xdim*0.5
-#                 else:
-#                     xdim = self.volumeRadius.get()
-#             else:
-#                 xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
-#                 xdim = xdim*0.5
+
 
         if self.halfVolumes:
             params = ' --vol %s' % self.vol1Fn

--- a/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
@@ -107,7 +107,9 @@ class XmippProtMonoRes(ProtAnalysis3D):
 
         line = group.addLine('Resolution Range (Å)',
                             help="If the user knows the range of resolutions or"
-                                " only a range of frequency needs to be analysed")
+                                " only a range of frequencies needs to be analysed." 
+                                "If Low is empty MonoRes will try to estimate the range. "
+                                "it should be better if a range is provided")
         
         group.addParam('significance', FloatParam, default=0.95, 
                        expertLevel=LEVEL_ADVANCED,

--- a/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
@@ -328,7 +328,7 @@ class XmippProtMonoRes(ProtAnalysis3D):
 
     def resolutionMonogenicSignalStep(self):
         # Number of frequencies
-        if (not self.maxRes.get().hasValue()):
+        if (not self.maxRes.hasValue()):
             self.resolutionMonogenicAuto()
             imageFile = self._getFileName(OUTPUT_RESOLUTION_FILE)
             min_, max_ = self.getMinMax(imageFile)

--- a/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_resolution_monogenic_signal.py
@@ -25,24 +25,29 @@
 # *
 # **************************************************************************
 from pyworkflow import VERSION_1_1
-from pyworkflow.protocol.params import (PointerParam, StringParam, BooleanParam, FloatParam, LEVEL_ADVANCED)
+from pyworkflow.protocol.params import (PointerParam, StringParam, 
+                                        BooleanParam, FloatParam, LEVEL_ADVANCED)
 from pyworkflow.em.protocol.protocol_3d import ProtAnalysis3D
-from convert import readSetOfVolumes
 from pyworkflow.object import Float
 from pyworkflow.em import ImageHandler
 from pyworkflow.utils import getExt
+from pyworkflow.em.data import Volume
 import numpy as np
 import pyworkflow.em.metadata as md
 
+CHIMERA_RESOLUTION_VOL = 'MG_Chimera_resolution.vol'
 
 MONORES_METHOD_URL = 'http://github.com/I2PC/scipion/wiki/XmippProtMonoRes'
 
-OUTPUT_RESOLUTION_FILE = 'mgresolution.vol'
-FN_FILTERED_MAP = 'filteredMap.vol'
-OUTPUT_RESOLUTION_FILE_CHIMERA = 'MG_Chimera_resolution.vol'
-OUTPUT_MASK_FILE = 'output_Mask.vol'
-FN_MEAN_VOL = 'mean_volume.vol'
-METADATA_MASK_FILE = 'mask_data.xmd'
+OUTPUT_RESOLUTION_FILE = 'resolutionMap'
+FN_FILTERED_MAP = 'filteredMap'
+OUTPUT_RESOLUTION_FILE_CHIMERA = 'outputChimera'
+OUTPUT_MASK_FILE = 'outputmask'
+FN_MEAN_VOL = 'meanvol'
+METADATA_MASK_FILE = 'metadataresolutions'
+FN_METADATA_HISTOGRAM = 'mdhist'
+BINARY_MASK = 'binarymask'
+FN_GAUSSIAN_MAP = 'gaussianfilter'
 
 
 class XmippProtMonoRes(ProtAnalysis3D):
@@ -55,58 +60,72 @@ class XmippProtMonoRes(ProtAnalysis3D):
     def __init__(self, **args):
         ProtAnalysis3D.__init__(self, **args)
         self.min_res_init = Float() 
-        self.max_res_init = Float() 
-        
+        self.max_res_init = Float()
+       
     
-    # --------------------------- DEFINE param functions --------------------------------------------
+    # --------------------------- DEFINE param functions ----------------------
     def _defineParams(self, form):
         form.addSection(label='Input')
 
         form.addParam('halfVolumes', BooleanParam, default=False,
                       label="Would you like to use half volumes?",
-                      help='The noise estimation for determining the local resolution '
-                           'is performed via half volumes.')
+                      help='The noise estimation for determining the '
+                      'local resolution is performed via half volumes.')
 
         form.addParam('inputVolumes', PointerParam, pointerClass='Volume',
                       label="Input Volume", important=True,
                       condition = 'not halfVolumes',
-                      help='Select a volume for determining its local resolution.')
+                      help='Select a volume for determining its '
+                      'local resolution.')
 
         form.addParam('inputVolume', PointerParam, pointerClass='Volume',
                       label="Volume Half 1", important=True,
                       condition = 'halfVolumes', 
-                      help='Select a volume for determining its local resolution.')
+                      help='Select a volume for determining its '
+                      'local resolution.')
 
         form.addParam('inputVolume2', PointerParam, pointerClass='Volume',
                       label="Volume Half 2", important=True,
                       condition='halfVolumes',
-                      help='Select a second volume for determining a local resolution.')
+                      help='Select a second volume for determining a '
+                      'local resolution.')
 
         form.addParam('Mask', PointerParam, pointerClass='VolumeMask', 
                       condition='(halfVolumes) or (not halfVolumes)',
-                      label="Binary Mask", important=True,
-                      help='The mask determines which points are specimen and which ones not')
+                      allowsNull=True,
+                      label="Binary Mask", 
+                      help='The mask determines which points are specimen'
+                      ' and which are not')
 
         group = form.addGroup('Extra parameters')
-        group.addParam('symmetry', StringParam, default='c1',
-                      label="Symmetry",
-                      help='Symmetry group. By default = c1.'
-                      'See [[http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Symmetry][Symmetry]]'
-                      'for a description of the symmetry groups format, If no symmetry is present, give c1.')
+#         group.addParam('symmetry', StringParam, default='c1',
+#                       label="Symmetry",
+#                       help='Symmetry group. By default = c1.'
+#                       'See [[http://xmipp.cnb.csic.es/twiki/bin/view/Xmipp/Symmetry][Symmetry]]'
+#                       'for a description of the symmetry groups format,' 
+#                       'If no symmetry is present, give c1.')
 
-        line = group.addLine('Resolution Range (A)',
-                            help="If the user knows the range of resolutions or only a"
-                                 " range of frequency needs to be analysed")
+        line = group.addLine('Resolution Range (Å)',
+                            help="If the user knows the range of resolutions or"
+                                " only a range of frequency needs to be analysed")
         
-        group.addParam('significance', FloatParam, default=0.95, expertLevel=LEVEL_ADVANCED,
+        group.addParam('significance', FloatParam, default=0.95, 
+                       expertLevel=LEVEL_ADVANCED,
                       label="Significance",
-                      help='Relution is computed using hipothesis tests, this value determines'
-                      'the significance of that test')
+                      help='Relution is computed using hipothesis tests, '
+                      'this value determines the significance of that test')
+        
+        group.addParam('maskthreshold', FloatParam, default=0.5, 
+                       expertLevel=LEVEL_ADVANCED,
+                      label="Mask threshold",
+                      help='If the provided mask is not binary. Then, MonoRes'
+                      'will try to binarize it. Bmask values below the threshold'
+                      'will be change to 0 and above the thresthol will be 1')
         
         group.addParam('isPremasked', BooleanParam, default=False,
                       label="Is the original premasked?",
-                      help='Sometimes the original volume is masked inside a spherical mask. In this case'
-                      'please select yes')
+                      help='Sometimes the original volume is masked inside '
+                      'a spherical mask. In this case please select yes')
         
         form.addParam('noiseonlyinhalves', BooleanParam, expertLevel=LEVEL_ADVANCED,
                       default=True,
@@ -118,10 +137,13 @@ class XmippProtMonoRes(ProtAnalysis3D):
         group.addParam('volumeRadius', FloatParam, default=-1,
                       label="Spherical mask radius (px)",
                       condition = 'isPremasked and not halfVolumes', 
-                      help='When the original volume is originally premasked, the noise estimation ought'
-                      'to be performed inside that premask, and out of the provieded mask asked in the previus'
-                      'box. The radius value, determines the radius of the spherical premask. By default'
-                      'radius = -1 use the half of the volume size as radius')
+                      help='When the original volume is originally premasked,'
+                      'the noise estimation ought to be performed inside'
+                      'that premask, and out of the provieded mask asked in'
+                      'the previus box. The radius value, determines the'
+                      'radius of the spherical premask. '
+                      'By default radius = -1 use the half of the '
+                      'volume size as radius')
         
         group.addParam('volumeRadiusHalf', FloatParam, default=-1,
                       label="Spherical mask radius (px)",
@@ -133,74 +155,122 @@ class XmippProtMonoRes(ProtAnalysis3D):
                       'the spherical premask. By default radius = -1 use the half'
                       'of the volume size as radius')
 
-        line.addParam('minRes', FloatParam, default=1, label='High')
-        line.addParam('maxRes', FloatParam, default=30, label='Low')
+        line.addParam('minRes', FloatParam, default=0, label='High')
+        line.addParam('maxRes', FloatParam, allowsNull=True, label='Low')
         line.addParam('stepSize', FloatParam, allowsNull=True,
                       expertLevel=LEVEL_ADVANCED, label='Step')
 
         group.addParam('filterInput', BooleanParam, default=False, 
                       label="Filter input volume with local resolution?",
-                      help='The input map is locally filtered at the local resolution map.')
+                      help='The input map is locally filtered at'
+                      'the local resolution map.')
+        
+        form.addParallelSection(threads = 4, mpi = 0)
 
     # --------------------------- INSERT steps functions --------------------------------------------
 
+    def _createFilenameTemplates(self):
+        """ Centralize how files are called """
+        myDict = {
+                 FN_MEAN_VOL: self._getExtraPath('mean_volume.vol'),
+                 OUTPUT_MASK_FILE: self._getExtraPath("output_Mask.vol"),
+                 OUTPUT_RESOLUTION_FILE_CHIMERA: self._getExtraPath(CHIMERA_RESOLUTION_VOL),
+                 FN_FILTERED_MAP: self._getExtraPath('filteredMap.vol'),
+                 OUTPUT_RESOLUTION_FILE: self._getExtraPath('mgresolution.vol'),
+                 METADATA_MASK_FILE: self._getExtraPath('mask_data.xmd'),
+                 FN_METADATA_HISTOGRAM: self._getExtraPath('hist.xmd'),
+                 BINARY_MASK: self._getExtraPath('binarized_mask.vol'),
+                 FN_GAUSSIAN_MAP: self._getExtraPath('gaussianfilted.vol')
+                 }
+        self._updateFilenamesDict(myDict)
+
     def _insertAllSteps(self):
+            # Convert input into xmipp Metadata format
+        self._createFilenameTemplates() 
+        self._insertFunctionStep('convertInputStep', )
+        self._insertFunctionStep('resolutionMonogenicSignalStep')
+        self._insertFunctionStep('createOutputStep')
+        self._insertFunctionStep("createHistrogram")
+
+    def convertInputStep(self):
+        """ Read the input volume.
+        """
         
         self.micsFn = self._getPath()
 
         if self.halfVolumes:
             self.vol1Fn = self.inputVolume.get().getFileName()
             self.vol2Fn = self.inputVolume2.get().getFileName()
-            self.maskFn = self.Mask.get().getFileName()
-
-            self.inputVolumes.set(None)
-
-        else:
-            self.vol0Fn = self.inputVolumes.get().getFileName()
-            self.maskFn = self.Mask.get().getFileName()
-            self.inputVolume.set(None)
-            self.inputVolume2.set(None)
-
-            # Convert input into xmipp Metadata format
-        convertId = self._insertFunctionStep('convertInputStep', )
-
-        MS = self._insertFunctionStep('resolutionMonogenicSignalStep',
-                                      prerequisites=[convertId])
-
-        self._insertFunctionStep('createOutputStep', prerequisites=[MS])
-
-        self._insertFunctionStep("createHistrogram")
-
-    def convertInputStep(self):
-        """ Read the input volume.
-        """
-        if (self.halfVolumes.get() is False):
-            extVol0 = getExt(self.vol0Fn)
-            if (extVol0 == '.mrc') or (extVol0 == '.map'):
-                self.vol0Fn = self.vol0Fn + ':mrc'
-
-        if self.halfVolumes.get() is True:
             extVol1 = getExt(self.vol1Fn)
             extVol2 = getExt(self.vol2Fn)
             if (extVol1 == '.mrc') or (extVol1 == '.map'):
                 self.vol1Fn = self.vol1Fn + ':mrc'
             if (extVol2 == '.mrc') or (extVol2 == '.map'):
                 self.vol2Fn = self.vol2Fn + ':mrc'
+                
+            if not self.Mask.hasValue():
+                self.ifNomask(self.vol1Fn)
+            else:
+                self.maskFn = self.Mask.get().getFileName()
+
+            self.inputVolumes.set(None)
+        else:
+            self.vol0Fn = self.inputVolumes.get().getFileName()
+            extVol0 = getExt(self.vol0Fn)
+            if (extVol0 == '.mrc') or (extVol0 == '.map'):
+                self.vol0Fn = self.vol0Fn + ':mrc'
+                
+            if not self.Mask.hasValue():
+                self.ifNomask(self.vol0Fn)
+            else:
+                self.maskFn = self.Mask.get().getFileName()
+            
+            print self.maskFn
+            
+            self.inputVolume.set(None)
+            self.inputVolume2.set(None)
+
 
         extMask = getExt(self.maskFn)
         if (extMask == '.mrc') or (extMask == '.map'):
             self.maskFn = self.maskFn + ':mrc'
+            
+        if self.Mask.hasValue():
+            params = ' -i %s' % self.maskFn
+            params += ' -o %s' % self._getFileName(BINARY_MASK)
+            params += ' --select below %f' % self.maskthreshold.get()
+            params += ' --substitute binarize'
+             
+            self.runJob('xmipp_transform_threshold', params)
 
-    def resolutionMonogenicSignalStep(self):
-
-        # Number of frequencies
-        if self.stepSize.hasValue():
-            Nfreqs = round((self.maxRes.get() - self.minRes.get())/self.stepSize.get())
-        else:
-            Nfreqs = 50
-  
+    def ifNomask(self, fnVol):
         if self.halfVolumes:
-            if self.isPremasked:
+            xdim, _ydim, _zdim = self.inputVolume.get().getDim()
+            params = ' -i %s' % fnVol
+        else:
+            xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
+            params = ' -i %s' % fnVol
+        params += ' -o %s' % self._getFileName(FN_GAUSSIAN_MAP)
+        setsize = 0.02*xdim
+        params += ' --fourier real_gaussian %f' % (setsize)
+     
+        self.runJob('xmipp_transform_filter', params)
+        img = ImageHandler().read(self._getFileName(FN_GAUSSIAN_MAP))
+        imgData = img.getData()
+        max_val = np.amax(imgData)*0.05
+         
+        params = ' -i %s' % self._getFileName(FN_GAUSSIAN_MAP)
+        params += ' --select below %f' % max_val
+        params += ' --substitute binarize'
+        params += ' -o %s' % self._getFileName(BINARY_MASK)
+     
+        self.runJob('xmipp_transform_threshold', params)
+        
+        self.maskFn = self._getFileName(BINARY_MASK)
+
+    def maskRadius(self, halfmaps, premaskedmap):
+        if halfmaps:
+            if premaskedmap:
                 if self.volumeRadiusHalf == -1:
                     xdim, _ydim, _zdim = self.inputVolume.get().getDim()
                     xdim = xdim*0.5
@@ -210,7 +280,7 @@ class XmippProtMonoRes(ProtAnalysis3D):
                 xdim, _ydim, _zdim = self.inputVolume.get().getDim()
                 xdim = xdim*0.5
         else:
-            if self.isPremasked:
+            if premaskedmap:
                 if self.volumeRadius == -1:
                     xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
                     xdim = xdim*0.5
@@ -219,55 +289,133 @@ class XmippProtMonoRes(ProtAnalysis3D):
             else:
                 xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
                 xdim = xdim*0.5
-                
-        if self.halfVolumes.get() is False:
-            params = ' --vol %s' % self.vol0Fn
-            params += ' --mask %s' % self.maskFn
-        else:
+        return xdim
+    
+    def resolutionMonogenicAuto(self):
+        freq_step = 1
+
+        xdim = self.maskRadius(self.halfVolumes, self.isPremasked)
+#         
+#         if self.halfVolumes:
+#             if self.isPremasked:
+#                 if self.volumeRadiusHalf == -1:
+#                     xdim, _ydim, _zdim = self.inputVolume.get().getDim()
+#                     xdim = xdim*0.5
+#                 else:
+#                     xdim = self.volumeRadiusHalf.get()
+#             else:
+#                 xdim, _ydim, _zdim = self.inputVolume.get().getDim()
+#                 xdim = xdim*0.5
+#         else:
+#             if self.isPremasked:
+#                 if self.volumeRadius == -1:
+#                     xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
+#                     xdim = xdim*0.5
+#                 else:
+#                     xdim = self.volumeRadius.get()
+#             else:
+#                 xdim, _ydim, _zdim = self.inputVolumes.get().getDim()
+#                 xdim = xdim*0.5
+
+        if self.halfVolumes:
             params = ' --vol %s' % self.vol1Fn
             params += ' --vol2 %s' % self.vol2Fn
-            params += ' --meanVol %s' % self._getExtraPath(FN_MEAN_VOL)
-            params += ' --mask %s' % self.maskFn
-        params += ' --mask_out %s' % self._getExtraPath(OUTPUT_MASK_FILE)
-        params += ' -o %s' % self._getExtraPath(OUTPUT_RESOLUTION_FILE)
-        if (self.halfVolumes):
+            params += ' --meanVol %s' % self._getFileName(FN_MEAN_VOL)
+            params += ' --mask %s' % self._getFileName(BINARY_MASK)
             params += ' --sampling_rate %f' % self.inputVolume.get().getSamplingRate()
             if (self.noiseonlyinhalves is False):
                 params += ' --noiseonlyinhalves'
         else:
+            params = ' --vol %s' % self.vol0Fn
+            params += ' --mask %s' % self._getFileName(BINARY_MASK)
             params += ' --sampling_rate %f' % self.inputVolumes.get().getSamplingRate()
-        params += ' --number_frequencies %f' % Nfreqs
-        params += ' --minRes %f' % self.minRes.get()
-        params += ' --maxRes %f' % self.maxRes.get()
+
+        params += ' --automatic '
+        params += ' --step %f' % freq_step
+        params += ' --mask_out %s' % self._getFileName(OUTPUT_MASK_FILE)
+        params += ' -o %s' % self._getFileName(OUTPUT_RESOLUTION_FILE)
         params += ' --volumeRadius %f' % xdim
-        params += ' --chimera_volume %s' % self._getExtraPath(OUTPUT_RESOLUTION_FILE_CHIMERA)
-        params += ' --sym %s' % self.symmetry.get()
+        params += ' --chimera_volume %s' % self._getFileName(
+                                                    OUTPUT_RESOLUTION_FILE_CHIMERA)
+        params += ' --sym %s' % 'c1'#self.symmetry.get()
         params += ' --significance %f' % self.significance.get()
-        params += ' --md_outputdata %s' % self._getExtraPath('mask_data.xmd')  
+        params += ' --md_outputdata %s' % self._getFileName(METADATA_MASK_FILE)  
+        params += ' --filtered_volume %s' % ''
+
+        self.runJob('xmipp_resolution_monogenic_signal', params)
+
+    def resolutionMonogenicSignalStep(self):
+        # Number of frequencies
+        if (not self.maxRes.get().hasValue()):
+            self.resolutionMonogenicAuto()
+            imageFile = self._getFileName(OUTPUT_RESOLUTION_FILE)
+            min_, max_ = self.getMinMax(imageFile)
+        else:    
+            max_ = self.maxRes.get()
+
+        if self.stepSize.hasValue():
+            freq_step = self.stepSize.get()
+        else:
+            freq_step = 0.25
+  
+        xdim = self.maskRadius(self.halfVolumes, self.isPremasked)
+
+        if self.halfVolumes:
+            params = ' --vol %s' % self.vol1Fn
+            params += ' --vol2 %s' % self.vol2Fn
+            params += ' --meanVol %s' % self._getFileName(FN_MEAN_VOL)
+            params += ' --mask %s' % self._getFileName(BINARY_MASK)
+            params += ' --sampling_rate %f' % self.inputVolume.get().getSamplingRate()
+            if (self.noiseonlyinhalves is False):
+                params += ' --noiseonlyinhalves'
+        else:
+            params = ' --vol %s' % self.vol0Fn
+            params += ' --mask %s' % self._getFileName(BINARY_MASK)
+            params += ' --sampling_rate %f' % self.inputVolumes.get().getSamplingRate()
+
+        params += ' --minRes %f' % self.minRes.get()
+        params += ' --maxRes %f' % max_
+            
+        params += ' --step %f' % freq_step
+        params += ' --mask_out %s' % self._getFileName(OUTPUT_MASK_FILE)
+        params += ' -o %s' % self._getFileName(OUTPUT_RESOLUTION_FILE)
+        params += ' --volumeRadius %f' % xdim
+        params += ' --exact'
+        params += ' --chimera_volume %s' % self._getFileName(
+                                                    OUTPUT_RESOLUTION_FILE_CHIMERA)
+        params += ' --sym %s' % 'c1'#self.symmetry.get()
+        params += ' --significance %f' % self.significance.get()
+        params += ' --md_outputdata %s' % self._getFileName(METADATA_MASK_FILE)  
         if self.filterInput.get():
-            params += ' --filtered_volume %s' % self._getExtraPath(FN_FILTERED_MAP)
+            params += ' --filtered_volume %s' % self._getFileName(FN_FILTERED_MAP)
         else:
             params += ' --filtered_volume %s' % ''
 
         self.runJob('xmipp_resolution_monogenic_signal', params)
 
 
+
     def createHistrogram(self):
 
-        params = ' -i %s' % self._getExtraPath(OUTPUT_RESOLUTION_FILE)
-        params += ' --mask binary_file %s' % self._getExtraPath(OUTPUT_MASK_FILE)
-        params += ' --steps %f' % 30
-        params += ' --range %f %f' % (self.min_res_init, self.max_res_init)#(self.minRes.get(), self.maxRes.get())
-        params += ' -o %s' % self._getExtraPath('hist.xmd')
+        M = float(self.max_res_init)
+        m = float(self.min_res_init)
+        range_res = round((M - m)*4.0)
+
+        params = ' -i %s' % self._getFileName(OUTPUT_RESOLUTION_FILE)
+        params += ' --mask binary_file %s' % self._getFileName(OUTPUT_MASK_FILE)
+        params += ' --steps %f' % (range_res)
+        params += ' --range %f %f' % (self.min_res_init, self.max_res_init)
+        params += ' -o %s' % self._getFileName(FN_METADATA_HISTOGRAM)
 
         self.runJob('xmipp_image_histogram', params)
         
         
     def readMetaDataOutput(self):
-        mData = md.MetaData(self._getExtraPath(METADATA_MASK_FILE))
+        mData = md.MetaData(self._getFileName(METADATA_MASK_FILE))
         NvoxelsOriginalMask = float(mData.getValue(md.MDL_COUNT, mData.firstObject()))
         NvoxelsOutputMask = float(mData.getValue(md.MDL_COUNT2, mData.firstObject()))
-        nvox = int(round(((NvoxelsOriginalMask-NvoxelsOutputMask)/NvoxelsOriginalMask)*100))
+        nvox = int(round(
+                ((NvoxelsOriginalMask-NvoxelsOutputMask)/NvoxelsOriginalMask)*100))
         return nvox
 
     def getMinMax(self, imageFile):
@@ -278,21 +426,20 @@ class XmippProtMonoRes(ProtAnalysis3D):
         return min_res, max_res
 
     def createOutputStep(self):
-        volume_path = self._getExtraPath(OUTPUT_RESOLUTION_FILE)
-        self.volumesSet = self._createSetOfVolumes('resolutionVol')
+        volume=Volume()
+        volume.setFileName(self._getFileName(OUTPUT_RESOLUTION_FILE))
         if (self.halfVolumes):
-            self.volumesSet.setSamplingRate(self.inputVolume.get().getSamplingRate())
+            volume.setSamplingRate(self.inputVolume.get().getSamplingRate())
+            self._defineOutputs(resolution_Volume=volume)
+            self._defineSourceRelation(self.inputVolume, volume)
         else:
-            self.volumesSet.setSamplingRate(self.inputVolumes.get().getSamplingRate())
-        readSetOfVolumes(volume_path, self.volumesSet)
-        self._defineOutputs(outputVolume=self.volumesSet)
-        if (self.halfVolumes):
-            self._defineSourceRelation(self.inputVolume, self.volumesSet)
-        else:
-            self._defineSourceRelation(self.inputVolumes, self.volumesSet)
+            volume.setSamplingRate(self.inputVolumes.get().getSamplingRate())
+            self._defineOutputs(resolution_Volume=volume)
+            self._defineSourceRelation(self.inputVolumes, volume)
+            
             
         #Setting the min max for the summary
-        imageFile = self._getExtraPath(OUTPUT_RESOLUTION_FILE_CHIMERA)
+        imageFile = self._getFileName(OUTPUT_RESOLUTION_FILE_CHIMERA)
         min_, max_ = self.getMinMax(imageFile)
         self.min_res_init.set(round(min_*100)/100)
         self.max_res_init.set(round(max_*100)/100)
@@ -301,24 +448,24 @@ class XmippProtMonoRes(ProtAnalysis3D):
 
         if self.filterInput.get():
             print 'Saving filtered map'
-            volume_filtered_path = self._getExtraPath(FN_FILTERED_MAP)
-            self.volumesSet2 = self._createSetOfVolumes('filteredVol')
+            volume.setFileName(self._getFileName(FN_FILTERED_MAP))
             if (self.halfVolumes):
-                self.volumesSet2.setSamplingRate(self.inputVolume.get().getSamplingRate())
+                volume.setSamplingRate(self.inputVolume.get().getSamplingRate())
+                self._defineOutputs(outputVolume_Filtered=volume)
+                self._defineSourceRelation(self.inputVolume, volume)
             else:
-                self.volumesSet2.setSamplingRate(self.inputVolumes.get().getSamplingRate())
-            readSetOfVolumes(volume_filtered_path, self.volumesSet2)
-            self._defineOutputs(outputVolume_Filtered=self.volumesSet2)
-            if (self.halfVolumes):
-                self._defineSourceRelation(self.inputVolume, self.volumesSet2)
-            else:
-                self._defineSourceRelation(self.inputVolumes, self.volumesSet2)
+                volume.setSamplingRate(self.inputVolumes.get().getSamplingRate())
+                self._defineOutputs(outputVolume_Filtered=volume)
+                self._defineSourceRelation(self.inputVolumes, volume)
+            
+
+                
 
     # --------------------------- INFO functions ------------------------------
 
     def _methods(self):
         messages = []
-        if hasattr(self, 'outputVolume'):
+        if hasattr(self, 'resolution_Volume'):
             messages.append(
                 'Information about the method/article in ' + MONORES_METHOD_URL)
         return messages
@@ -328,15 +475,8 @@ class XmippProtMonoRes(ProtAnalysis3D):
         summary.append("Highest resolution %.2f Å,   "
                        "Lowest resolution %.2f Å. \n" % (self.min_res_init,
                                                          self.max_res_init))
-        Nvox = self.readMetaDataOutput()
-
-        if (Nvox>10):
-            summary.append("The resolution of %i %% of the mask voxels could not be computed. Maybe the mask was"
-            "not correctly created, it is too wide or the resolution range does not cover the resolution at those voxels. "
-            "If it is not the problem, decrease the significance in the advaced parameters can be an alternative" % Nvox)
-
         return summary
 
     def _citations(self):
-        return ['Vilas2017']
+        return ['Vilas2018']
 

--- a/pyworkflow/em/packages/xmipp3/protocol_rotational_spectra.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_rotational_spectra.py
@@ -193,6 +193,7 @@ class XmippProtRotSpectra(KendersomBaseClassify):
         
         plotFile = join(self.plotsDir, 'spectra_%s%06d.png' % (label, objId))
         plotter.savefig(plotFile)
+        plotter.close()
         
         return plotFile
         

--- a/pyworkflow/em/packages/xmipp3/viewer_resolution_monogenic_signal.py
+++ b/pyworkflow/em/packages/xmipp3/viewer_resolution_monogenic_signal.py
@@ -28,7 +28,7 @@ from pyworkflow.gui.plotter import Plotter
 from pyworkflow.protocol.params import LabelParam, StringParam, EnumParam
 from pyworkflow.viewer import ProtocolViewer, DESKTOP_TKINTER
 from pyworkflow.em.viewer import ChimeraView, DataView
-from protocol_resolution_monogenic_signal import XmippProtMonoRes, OUTPUT_RESOLUTION_FILE
+from protocol_resolution_monogenic_signal import XmippProtMonoRes
 from pyworkflow.em.metadata import MetaData, MDL_X, MDL_COUNT
 from pyworkflow.em import ImageHandler
 import numpy as np
@@ -133,7 +133,7 @@ class XmippMonoResViewer(ProtocolViewer):
                 }
        
     def _showVolumeSlices(self, param=None):
-        cm = DataView(self.protocol.outputVolume.getFileName())
+        cm = DataView(self.protocol.resolution_Volume.getFileName())
         
         return [cm]
     
@@ -148,7 +148,7 @@ class XmippMonoResViewer(ProtocolViewer):
         
     
     def _showVolumeColorSlices(self, param=None):
-        imageFile = self.protocol._getExtraPath(OUTPUT_RESOLUTION_FILE)
+        imageFile = self.protocol.resolution_Volume.getFileName()
         img = ImageHandler().read(imageFile)
         imgData = img.getData()
         max_Res = np.amax(imgData)

--- a/pyworkflow/gui/project/constants.py
+++ b/pyworkflow/gui/project/constants.py
@@ -40,3 +40,6 @@ STATUS_COLORS = {
                STATUS_ABORTED: '#F5CCCB',
                STATUS_SCHEDULED: '#F3F5CB'
                }
+
+# For protocols with warnings
+WARNING_COLOR = '#848484'

--- a/pyworkflow/gui/project/utils.py
+++ b/pyworkflow/gui/project/utils.py
@@ -23,7 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
-from pyworkflow.gui.project.constants import STATUS_COLORS
+from pyworkflow.gui.project.constants import STATUS_COLORS, WARNING_COLOR
 from pyworkflow.protocol import STATUS_FAILED
 
 
@@ -41,7 +41,10 @@ def getStatusColorFromRun(prot):
     """
 
     if prot:
-        return getStatusColor(prot.status.get(STATUS_FAILED))
+        if prot.hasSummaryWarnings():
+            return WARNING_COLOR
+        else:
+            return getStatusColor(prot.status.get(STATUS_FAILED))
     else:
         return getStatusColor()
 

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -530,11 +530,20 @@ class RunIOTreeProvider(pwgui.tree.TreeProvider):
                         suffix = '[%s]' % extendedValue
                     elif obj.hasExtended():
                         suffix = '[Item %s]' % extendedValue
-                    if obj.get() is None:
-                        labelObj = obj.getObjValue()
-                        suffix = ''
-                    else:
-                        labelObj = obj.get()
+
+                    # Tolerate loading projects:
+                    # When having only the project sqlite..an obj.get() will
+                    # the load of the set...and if it is missing this whole
+                    # "thread" fails.
+                    try:
+                        if obj.get() is None:
+                            labelObj = obj.getObjValue()
+                            suffix = ''
+                        else:
+                            labelObj = obj.get()
+                    except Exception as e:
+                        return  {'parent': parent, 'image': image,
+                                'text': name, 'values': ("Couldn't read object attributes.",)}
                 else:
                     labelObj = obj.get()
 

--- a/pyworkflow/mapper/sqlite.py
+++ b/pyworkflow/mapper/sqlite.py
@@ -711,7 +711,8 @@ class SqliteFlatMapper(Mapper):
             if not self.doCreateTables:
                 self.__loadObjDict()
         except Exception as ex:
-            raise Exception('Error creating SqliteFlatMapper, dbName: %s, tablePrefix: %s\n error: %s' %
+            raise SqliteFlatMapperException('Error creating SqliteFlatMapper, '
+                            'dbName: %s, tablePrefix: %s\n error: %s' %
                             (dbName, tablePrefix, ex))
     
     def commit(self):
@@ -919,6 +920,10 @@ class SqliteFlatMapper(Mapper):
     def getPropertyKeys(self):
         return self.db.getPropertyKeys()
         
+
+class SqliteFlatMapperException(Exception):
+    pass
+
 
 SELF = 'self'
 

--- a/pyworkflow/project.py
+++ b/pyworkflow/project.py
@@ -1029,7 +1029,14 @@ class Project(object):
             self.runs = self.mapper.selectAllBatch(objectFilter=lambda o: isinstance(o, pwprot.Protocol))
 
             for r in self.runs:
-                self._setProtocolMapper(r)
+
+                # Tolerate loading errors. For support.
+                # When only having the sqlite, sometime there are exceptions here
+                # due to the absence of a set.
+                try:
+                    self._setProtocolMapper(r)
+                except Exception as e:
+                    print("Protocol %s couldn't be loaded. %s" % (r, e))
 
                 # Check for run warnings
                 r.checkSummaryWarnings()

--- a/pyworkflow/project.py
+++ b/pyworkflow/project.py
@@ -995,9 +995,22 @@ class Project(object):
 
     def _setProtocolMapper(self, protocol):
         """ Set the project and mapper to the protocol. """
-        protocol.setProject(self)
-        protocol.setMapper(self.mapper)
-        self._setHostConfig(protocol)
+
+        # Tolerate loading errors. For support.
+        # When only having the sqlite, sometime there are exceptions here
+        # due to the absence of a set.
+        from pyworkflow.mapper.sqlite import SqliteFlatMapperException
+        try:
+
+            protocol.setProject(self)
+            protocol.setMapper(self.mapper)
+            self._setHostConfig(protocol)
+
+        except SqliteFlatMapperException:
+            protocol.addSummaryWarning(
+                "*Protocol loading problem*: A set related to this "
+                "protocol couldn't be loaded.")
+
 
     def _setupProtocol(self, protocol):
         """Insert a new protocol instance in the database"""
@@ -1030,13 +1043,7 @@ class Project(object):
 
             for r in self.runs:
 
-                # Tolerate loading errors. For support.
-                # When only having the sqlite, sometime there are exceptions here
-                # due to the absence of a set.
-                try:
-                    self._setProtocolMapper(r)
-                except Exception as e:
-                    print("Protocol %s couldn't be loaded. %s" % (r, e))
+                self._setProtocolMapper(r)
 
                 # Check for run warnings
                 r.checkSummaryWarnings()

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -1528,6 +1528,9 @@ class Protocol(Step):
         MODE_RESTART or MODE_RESUME. """
         return self.runMode.get()
 
+    def hasSummaryWarnings(self):
+        return len(self.summaryWarnings) != 0
+
     def addSummaryWarning(self, warningDescription):
         """Appends the warningDescription param to the list of summaryWarnings.
         Will be printed in the protocol summary."""
@@ -1536,16 +1539,14 @@ class Protocol(Step):
 
     def checkSummaryWarnings(self):
         """ Checks for warnings that we want to tell the user about by adding a
-        warning sign to the run box and a description to the run summary. Returns
-        summaryWarnings with any changes made to it during the check.
+        warning sign to the run box and a description to the run summary.
         List of warnings checked:
         1. If the folder for this protocol run exists.
         """
         if not self.isSaved() and not os.path.exists(self.workingDir.get()):
-            self.addSummaryWarning((
-                                   "*Missing run data*: The directory for this run is missing, so it won't be"
-                                   "possible to use its outputs in other protocols."))
-        return self.summaryWarnings
+            self.addSummaryWarning("*Missing run data*: The directory for this "
+                                   "run is missing, so it won't be possible to "
+                                   "use its outputs in other protocols.")
 
     def isContinued(self):
         """ Return if running in continue mode (MODE_RESUME). """

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -592,8 +592,21 @@ class Protocol(Step):
         emptyPointers = []
 
         for paramName, attr in self.iterInputPointers():
-            condition = self.evalParamCondition(paramName)
+
             param = self.getParam(paramName)
+            # Issue #1597: New data loaded with old code.
+            # If the input pointer is not a param:
+            # This could happen in backward incompatibility cases,
+            # Protocol has an attribute (inputPointer) but class does not define
+            # if in the define params.
+            if param is None:
+                print("%s attribute is not defined as parameter. "
+                      "This could happen when loading new code with older "
+                      "scipion versions." % paramName)
+                continue
+
+            condition = self.evalParamCondition(paramName)
+
             obj = attr.get()
             if condition and obj is None and not param.allowsNull:
                 if attr.hasValue():

--- a/pyworkflow/tests/em/protocols/test_protocols_monores.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_monores.py
@@ -27,7 +27,7 @@
 import unittest, sys
 # import numpy as np
 from pyworkflow.em import exists
-from pyworkflow.em.packages.xmipp3.protocol_resolution_monogenic_signal import OUTPUT_RESOLUTION_FILE
+#from pyworkflow.em.packages.xmipp3.protocol_resolution_monogenic_signal import OUTPUT_RESOLUTION_FILE
 from pyworkflow.tests import BaseTest, DataSet, setupTestProject
 from pyworkflow.em.packages.xmipp3 import XmippProtMonoRes, XmippProtCreateMask3D
 from pyworkflow.em.protocol import ProtImportVolumes
@@ -95,7 +95,7 @@ class TestMonoRes(TestMonoResBase):
                                    filterInput=False,
                                    )
         self.launchProtocol(MonoRes)
-        self.assertTrue(exists(MonoRes._getExtraPath(OUTPUT_RESOLUTION_FILE)),
+        self.assertTrue(exists(MonoRes._getExtraPath('mgresolution.vol')),
                         "MonoRes (no split, no premasked) has failed")
  
     def testMonoRes2(self):
@@ -114,7 +114,7 @@ class TestMonoRes(TestMonoResBase):
                                    filterInput=False,
                                    )
         self.launchProtocol(MonoRes)
-        self.assertTrue(exists(MonoRes._getExtraPath(OUTPUT_RESOLUTION_FILE)),
+        self.assertTrue(exists(MonoRes._getExtraPath('mgresolution.vol')),
                         "MonoRes (split, pre-masked, no filter) has failed")
  
     def testMonoRes3(self):
@@ -131,5 +131,5 @@ class TestMonoRes(TestMonoResBase):
                                    filterInput=True,
                                    )
         self.launchProtocol(MonoRes)
-        self.assertTrue(exists(MonoRes._getExtraPath(OUTPUT_RESOLUTION_FILE)),
+        self.assertTrue(exists(MonoRes._getExtraPath('mgresolution.vol')),
                         "MonoRes filter has failed")

--- a/pyworkflow/web/app/wizards/resmap_wizard.py
+++ b/pyworkflow/web/app/wizards/resmap_wizard.py
@@ -159,8 +159,8 @@ def getPlotResMap(request, protocol):
     plotter = _runPreWhiteningWeb(protocol, results)
     #3rd step: Save to png image
     
-#     plotUrl = "/" + savePlot(request, plotter)
-    plotUrl = savePlot(request, plotter) 
+    plotUrl = savePlot(request, plotter)
+    plotter.close()
     return plotUrl, min_ang
 
 def _beforePreWhitening(protocol, dir):

--- a/software/em/xmipp/libraries/reconstruction/resolution_monogenic_signal.cpp
+++ b/software/em/xmipp/libraries/reconstruction/resolution_monogenic_signal.cpp
@@ -42,13 +42,15 @@ void ProgMonogenicSignalRes::readParams()
 	minRes = getDoubleParam("--minRes");
 	maxRes = getDoubleParam("--maxRes");
 	fnSym = getParam("--sym");
-	N_freq = getDoubleParam("--number_frequencies");
+	freq_step = getDoubleParam("--step");
 	trimBound = getDoubleParam("--trimmed");
 	exactres = checkParam("--exact");
 	noiseOnlyInHalves = checkParam("--noiseonlyinhalves");
 	fnSpatial = getParam("--filtered_volume");
 	significance = getDoubleParam("--significance");
 	fnMd = getParam("--md_outputdata");
+	automaticMode = checkParam("--automatic");
+	nthrs = getIntParam("--threads");
 }
 
 
@@ -69,7 +71,7 @@ void ProgMonogenicSignalRes::defineParams()
 	addParamsLine("  [--sampling_rate <s=1>]   : Sampling rate (A/px)");
 	addParamsLine("                            : Use -1 to disable this option");
 	addParamsLine("  [--volumeRadius <s=100>]   : This parameter determines the radius of a sphere where the volume is");
-	addParamsLine("  [--number_frequencies <w=50>]       : The resolution is computed at a number of frequencies between mininum and");
+	addParamsLine("  [--step <s=0.25>]       : The resolution is computed at a number of frequencies between mininum and");
 	addParamsLine("                            : maximum resolution px/A. This parameter determines that number");
 	addParamsLine("  [--minRes <s=30>]         : Minimum resolution (A)");
 	addParamsLine("  [--maxRes <s=1>]          : Maximum resolution (A)");
@@ -83,7 +85,10 @@ void ProgMonogenicSignalRes::defineParams()
 	addParamsLine("                                  : Moreover, voxels inside the mask cannot be measured due to an unsignificant");
 	addParamsLine("                                  : SNR. Thus, a new mask is created. This metadata file, shows, the number of");
 	addParamsLine("                                  : voxels of the original mask, and the created mask");
+	addParamsLine("  [--automatic]                   : Resolution range is not neccesary provided");
+	addParamsLine("  [--threads <s=4>]               : Number of threads");
 }
+
 
 void ProgMonogenicSignalRes::produceSideInfo()
 {
@@ -104,6 +109,8 @@ void ProgMonogenicSignalRes::produceSideInfo()
 	}
 	V().setXmippOrigin();
 
+
+	transformer_inv.setThreadsNumber(nthrs);
 
 	FourierTransformer transformer;
 	MultidimArray<double> &inputVol = V();
@@ -170,7 +177,7 @@ void ProgMonogenicSignalRes::produceSideInfo()
 	FOR_ALL_ELEMENTS_IN_ARRAY3D(pMask)
 	{
 		if (A3D_ELEM(pMask, k, i, j) == 1)
-			NVoxelsOriginalMask++;
+			++NVoxelsOriginalMask;
 		if (i*i+j*j+k*k > R*R)
 			A3D_ELEM(pMask, k, i, j) = -1;
 	}
@@ -199,33 +206,52 @@ void ProgMonogenicSignalRes::produceSideInfo()
 		fftN=&fftV;
 	}
 	V.clear();
+
+	double u;
+	int size_fourier = ZSIZE(fftV);
+	freq_fourier.initZeros(size_fourier);
+
+	int size = ZSIZE(pMask);
+
+	VEC_ELEM(freq_fourier,0) = 1e-38;
+	for(size_t k=0; k<size_fourier; ++k)
+	{
+		FFT_IDX2DIGFREQ(k,size, u);
+		VEC_ELEM(freq_fourier,k) = u;
+	}
 }
 
 
 void ProgMonogenicSignalRes::amplitudeMonogenicSignal3D(MultidimArray< std::complex<double> > &myfftV,
-		double w1, double w1h, double w1l, MultidimArray<double> &amplitude, int count, FileName fnDebug)
+		double freq, double freqH, double freqL, MultidimArray<double> &amplitude, int count, FileName fnDebug)
 {
 	fftVRiesz.initZeros(myfftV);
-	amplitude.resizeNoCopy(VRiesz);
+	fftVRiesz_aux.initZeros(myfftV);
 	std::complex<double> J(0,1);
 
 	// Filter the input volume and add it to amplitude
 	long n=0;
-	double iw=1.0/w1;
-	double iwl=1.0/w1l;
-	double ideltal=PI/(w1-w1l);
+	double ideltal=PI/(freq-freqH);
 
 	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(myfftV)
 	{
 		double iun=DIRECT_MULTIDIM_ELEM(iu,n);
 		double un=1.0/iun;
-		if (w1l<=un && un<=w1)
+		if (freqH<=un && un<=freq)
 		{
 			//double H=0.5*(1+cos((un-w1)*ideltal));
 			DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = DIRECT_MULTIDIM_ELEM(myfftV, n);
-			DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= 0.5*(1+cos((un-w1)*ideltal));//H;
-		} else if (un>w1)
+			DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= 0.5*(1+cos((un-freq)*ideltal));//H;
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) = -J;
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) *= DIRECT_MULTIDIM_ELEM(fftVRiesz, n);
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) *= iun;
+		} else if (un>freq)
+		{
 			DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = DIRECT_MULTIDIM_ELEM(myfftV, n);
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) = -J;
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) *= DIRECT_MULTIDIM_ELEM(fftVRiesz, n);
+			DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) *= iun;
+		}
 	}
 
 	transformer_inv.inverseFourierTransform(fftVRiesz, VRiesz);
@@ -251,112 +277,53 @@ void ProgMonogenicSignalRes::amplitudeMonogenicSignal3D(MultidimArray< std::comp
 	saveImg2.clear(); 
 	#endif
 
+	amplitude.resizeNoCopy(VRiesz);
 
 	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
-	DIRECT_MULTIDIM_ELEM(amplitude,n)=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
+		DIRECT_MULTIDIM_ELEM(amplitude,n)=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
 
 	// Calculate first component of Riesz vector
-	fftVRiesz.initZeros(myfftV);
 	double uz, uy, ux;
-	n=0;
-
-	for(size_t j=0; j<XSIZE(myfftV); ++j)
-	{
-		FFT_IDX2DIGFREQ(j,YSIZE(amplitude),ux);
-		for(size_t k=0; k<ZSIZE(myfftV); ++k)
-		{
-			for(size_t i=0; i<YSIZE(myfftV); ++i)
-			{
-				double iun=DIRECT_MULTIDIM_ELEM(iu,n);
-				double un=1.0/iun;
-				if (w1l<=un && un<=w1)
-				{
-					//double H=0.5*(1+cos((un-w1)*ideltal));
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-J*ux*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *=0.5*(1+cos((un-w1)*ideltal));//H;
-					//Next lines are an optimization of the commented ones
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= -ux*iun*0.5*(1+cos((un-w1)*ideltal));//H;
-				} else if (un>w1)
-				{
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-ux*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-				}
-				++n;
-			}
-		}
-	}
-	transformer_inv.inverseFourierTransform(fftVRiesz, VRiesz);
-	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
-	DIRECT_MULTIDIM_ELEM(amplitude,n)+=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
-
-	// Calculate second component of Riesz vector
-	fftVRiesz.initZeros(myfftV);
-	n=0;
-
-	for(size_t i=0; i<YSIZE(myfftV); ++i)
-	{
-		FFT_IDX2DIGFREQ(i,YSIZE(amplitude),uy);
-		for(size_t k=0; k<ZSIZE(myfftV); ++k)
-		{
-			for(size_t j=0; j<XSIZE(myfftV); ++j)
-			{
-				double iun=DIRECT_MULTIDIM_ELEM(iu,n);
-				double un=1.0/iun;
-				if (w1l<=un && un<=w1)
-				{
-					//double H=0.5*(1+cos((un-w1)*ideltal));
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-J*uy*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *=0.5*(1+cos((un-w1)*ideltal));//H;
-					//Next lines are an optimization of the commented ones
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= -uy*iun*0.5*(1+cos((un-w1)*ideltal));//H;
-				} else if (un>w1)
-				{
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-uy*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-				}
-				++n;
-			}
-		}
-	}
-	transformer_inv.inverseFourierTransform(fftVRiesz, VRiesz);
-	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
-	DIRECT_MULTIDIM_ELEM(amplitude,n)+=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
-
-	// Calculate third component of Riesz vector
-	fftVRiesz.initZeros(myfftV);
 	n=0;
 	for(size_t k=0; k<ZSIZE(myfftV); ++k)
 	{
-		FFT_IDX2DIGFREQ(k,ZSIZE(amplitude),uz);
 		for(size_t i=0; i<YSIZE(myfftV); ++i)
 		{
 			for(size_t j=0; j<XSIZE(myfftV); ++j)
 			{
-				double iun=DIRECT_MULTIDIM_ELEM(iu,n);
-				double un=1.0/iun;
-				if (w1l<=un && un<=w1)
-				{
-					//double H=0.5*(1+cos((un-w1)*ideltal));
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-J*uz*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					//DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= 0.5*(1+cos((un-w1)*ideltal));//H;
-					//Next lines are an optimization of the commented ones
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= -uz*iun*0.5*(1+cos((un-w1)*ideltal));//H;
-				} else if (un>w1)
-				{
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = (-uz*iun)*DIRECT_MULTIDIM_ELEM(myfftV, n);
-					DIRECT_MULTIDIM_ELEM(fftVRiesz, n) *= J;
-				}
+				ux = VEC_ELEM(freq_fourier,j);
+				DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = ux*DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n);
 				++n;
 			}
 		}
 	}
 	transformer_inv.inverseFourierTransform(fftVRiesz, VRiesz);
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
+		DIRECT_MULTIDIM_ELEM(amplitude,n)+=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
+
+	// Calculate second and third components of Riesz vector
+	n=0;
+	for(size_t k=0; k<ZSIZE(myfftV); ++k)
+	{
+		uz = VEC_ELEM(freq_fourier,k);
+		for(size_t i=0; i<YSIZE(myfftV); ++i)
+		{
+			uy = VEC_ELEM(freq_fourier,i);
+			for(size_t j=0; j<XSIZE(myfftV); ++j)
+			{
+				DIRECT_MULTIDIM_ELEM(fftVRiesz, n) = uy*DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n);
+				DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n) = uz*DIRECT_MULTIDIM_ELEM(fftVRiesz_aux, n);
+				++n;
+			}
+		}
+	}
+	transformer_inv.inverseFourierTransform(fftVRiesz, VRiesz);
+
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
+		DIRECT_MULTIDIM_ELEM(amplitude,n)+=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
+
+	transformer_inv.inverseFourierTransform(fftVRiesz_aux, VRiesz);
+
 	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
 	{
 		DIRECT_MULTIDIM_ELEM(amplitude,n)+=DIRECT_MULTIDIM_ELEM(VRiesz,n)*DIRECT_MULTIDIM_ELEM(VRiesz,n);
@@ -374,9 +341,29 @@ void ProgMonogenicSignalRes::amplitudeMonogenicSignal3D(MultidimArray< std::comp
 	#endif // DEBUG
 //
 	// Low pass filter the monogenic amplitude
-	lowPassFilter.w1 = w1;
-	amplitude.setXmippOrigin();
-	lowPassFilter.applyMaskSpace(amplitude);
+	transformer_inv.FourierTransform(amplitude, fftVRiesz, false);
+	double raised_w = PI/(freqL-freq);
+
+	n=0;
+
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(fftVRiesz)
+	{
+		double un=1.0/DIRECT_MULTIDIM_ELEM(iu,n);
+//		std::cout << "un = " << un << "  freqL = " << freqL << " freq = " << freq << std::endl;
+		if ((freqL)>=un && un>=freq)
+		{
+			DIRECT_MULTIDIM_ELEM(fftVRiesz,n) *= 0.5*(1 + cos(raised_w*(un-freq)));
+		}
+		else
+		{
+			if (un>freqL)
+			{
+				DIRECT_MULTIDIM_ELEM(fftVRiesz,n) = 0;
+			}
+		}
+	}
+	transformer_inv.inverseFourierTransform();
+
 
 	#ifdef DEBUG
 	saveImg2 = amplitude;
@@ -391,24 +378,84 @@ void ProgMonogenicSignalRes::amplitudeMonogenicSignal3D(MultidimArray< std::comp
 }
 
 
+void ProgMonogenicSignalRes::firstMonoResEstimation(MultidimArray< std::complex<double> > &myfftV,
+		double freq, double freqH, double freqL, MultidimArray<double> &amplitude,
+		int count, FileName fnDebug, double &mean_Signal, double &mean_noise, double &thresholdFirstEstimation)
+{
+	amplitudeMonogenicSignal3D(myfftV, freq, freqH, freqL, amplitude, count, fnDebug);
+
+	double sumS=0, sumS2=0, sumN=0, sumN2=0, NN = 0, NS = 0;
+	MultidimArray<int> &pMask = mask();
+	std::vector<double> noiseValues;
+
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitude)
+	{
+		double amplitudeValue=DIRECT_MULTIDIM_ELEM(amplitude, n);
+		if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
+		{
+			sumS  += amplitudeValue;
+			++NS;
+		}
+		else if (DIRECT_MULTIDIM_ELEM(pMask, n)==0)
+		{
+			noiseValues.push_back(amplitudeValue);
+			sumN  += amplitudeValue;
+			++NN;
+		}
+	}
+	std::sort(noiseValues.begin(),noiseValues.end());
+
+	mean_Signal = sumS/NS;
+	mean_noise = sumN/NN;
+
+	std::cout << "means_signal = " << mean_Signal << "mean_noise = " << mean_noise << std::endl;
+
+	thresholdFirstEstimation = noiseValues[size_t(noiseValues.size()*significance)];
+
+
+}
+
+
 void ProgMonogenicSignalRes::postProcessingLocalResolutions(MultidimArray<double> &resolutionVol,
 		std::vector<double> &list, MultidimArray<double> &resolutionChimera, double &cut_value, MultidimArray<int> &pMask)
 {
 	MultidimArray<double> resolutionVol_aux = resolutionVol;
-	double last_resolution_2 = sampling/list[(list.size()-1)];
+	double last_resolution_2 = list[(list.size()-1)];
+
+	double Nyquist;
+	Nyquist = 2*sampling;
 
 	// Count number of voxels with resolution
 	size_t N=0;
-	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
-		if (DIRECT_MULTIDIM_ELEM(resolutionVol, n)>(last_resolution_2-0.001)) //the value 0.001 is a tolerance
-			++N;
+	if (automaticMode)
+	{
+		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
+			if (DIRECT_MULTIDIM_ELEM(resolutionVol, n)>=(Nyquist)) //the value 0.001 is a tolerance
+				++N;
+	}
+	else
+	{
+		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
+			if (DIRECT_MULTIDIM_ELEM(resolutionVol, n)>=(last_resolution_2-0.001)) //the value 0.001 is a tolerance
+				++N;
+	}
+
 
 	// Get all resolution values
 	MultidimArray<double> resolutions(N);
 	size_t N_iter=0;
+	if (automaticMode)
+	{
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
+		if (DIRECT_MULTIDIM_ELEM(resolutionVol, n)>=Nyquist)
+			DIRECT_MULTIDIM_ELEM(resolutions,N_iter++)=DIRECT_MULTIDIM_ELEM(resolutionVol, n);
+	}
+	else
+	{
 	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
 		if (DIRECT_MULTIDIM_ELEM(resolutionVol, n)>(last_resolution_2-0.001))
 			DIRECT_MULTIDIM_ELEM(resolutions,N_iter++)=DIRECT_MULTIDIM_ELEM(resolutionVol, n);
+	}
 	// Sort value and get threshold
 	std::sort(&A1D_ELEM(resolutions,0),&A1D_ELEM(resolutions,N));
 	double filling_value = A1D_ELEM(resolutions, (int)(0.5*N)); //median value
@@ -416,26 +463,47 @@ void ProgMonogenicSignalRes::postProcessingLocalResolutions(MultidimArray<double
 
 	double freq, res, init_res, last_res;
 
-	init_res = sampling/list[0];
-	last_res = sampling/list[(list.size()-1)];
+	init_res = list[0];
+	last_res = list[(list.size()-1)];
 	
 	std::cout << "--------------------------" << std::endl;
 	std::cout << "last_res = " << last_res << std::endl;
 
 	resolutionChimera = resolutionVol;
 
-	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
+	if (automaticMode)
 	{
-		if (DIRECT_MULTIDIM_ELEM(resolutionVol, n) < last_res)
+		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
 		{
-			DIRECT_MULTIDIM_ELEM(resolutionChimera, n) = filling_value;
-			DIRECT_MULTIDIM_ELEM(resolutionVol, n) = 0;
-			DIRECT_MULTIDIM_ELEM(pMask,n) = 0;
+			if (DIRECT_MULTIDIM_ELEM(pMask,n) == 0)
+			{
+			  DIRECT_MULTIDIM_ELEM(resolutionChimera, n) = filling_value;
+			}
 		}
-		if (DIRECT_MULTIDIM_ELEM(resolutionVol, n) >= trimming_value)
+	}
+	else
+	{
+		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(resolutionVol)
 		{
-		  DIRECT_MULTIDIM_ELEM(pMask,n) = 0;
-		  DIRECT_MULTIDIM_ELEM(resolutionVol, n) = 0;
+			if (DIRECT_MULTIDIM_ELEM(resolutionVol, n) < last_res)
+			{
+				if (DIRECT_MULTIDIM_ELEM(pMask, n) >=1)
+				{
+					DIRECT_MULTIDIM_ELEM(resolutionChimera, n) = filling_value;
+					DIRECT_MULTIDIM_ELEM(resolutionVol, n) = filling_value;
+				}
+				else
+				{
+					DIRECT_MULTIDIM_ELEM(resolutionChimera, n) = filling_value;
+					DIRECT_MULTIDIM_ELEM(pMask,n) = 0;
+				}
+			}
+			if (DIRECT_MULTIDIM_ELEM(resolutionVol, n) > trimming_value)
+			{
+			  DIRECT_MULTIDIM_ELEM(pMask,n) = 0;
+			  DIRECT_MULTIDIM_ELEM(resolutionVol, n) = filling_value;
+			  DIRECT_MULTIDIM_ELEM(resolutionChimera, n) = filling_value;
+			}
 		}
 	}
 	//#ifdef DEBUG_MASK
@@ -443,6 +511,79 @@ void ProgMonogenicSignalRes::postProcessingLocalResolutions(MultidimArray<double
 	imgMask = pMask;
 	imgMask.write(fnMaskOut);
 	//#endif
+}
+
+void ProgMonogenicSignalRes::resolution2eval(int &count_res, double step,
+								double &resolution, double &last_resolution,
+								double &freq, double &freqL,
+								int &last_fourier_idx,
+								bool &continueIter,	bool &breakIter,
+								bool &doNextIteration)
+{
+	if (automaticMode)
+		resolution = minRes + count_res*step;
+	else
+		resolution = maxRes - count_res*step;
+	freq = sampling/resolution;
+	++count_res;
+
+	double Nyquist = 2*sampling;
+	double aux_frequency;
+	int fourier_idx;
+
+	DIGFREQ2FFT_IDX(freq, ZSIZE(VRiesz), fourier_idx);
+
+//	std::cout << "Resolution = " << resolution << "   iter = " << count_res-1 << std::endl;
+//	std::cout << "freq = " << freq << "   Fourier index = " << fourier_idx << std::endl;
+
+	FFT_IDX2DIGFREQ(fourier_idx, ZSIZE(VRiesz), aux_frequency);
+
+	freq = aux_frequency;
+
+	if (fourier_idx == last_fourier_idx)
+	{
+//		std::cout << "entro en el if"  << std::endl;
+		continueIter = true;
+		return;
+	}
+
+	last_fourier_idx = fourier_idx;
+	resolution = sampling/aux_frequency;
+
+
+	if (count_res == 0)
+		last_resolution = resolution;
+
+	if ( ( resolution<Nyquist ))// || (resolution > last_resolution) )
+	{
+		//std::cout << "Nyquist limit reached" << std::endl;
+		breakIter = true;
+		return;
+	}
+//	if ( ( freq>0.495))// || (resolution > last_resolution) )
+//	{
+//		std::cout << "Nyquist limit reached" << std::endl;
+//		doNextIteration = false;
+//		return;
+//	}
+
+	freqL = sampling/(resolution + step);
+
+	int fourier_idx_2;
+
+	DIGFREQ2FFT_IDX(freqL, ZSIZE(VRiesz), fourier_idx_2);
+
+	if (fourier_idx_2 == fourier_idx)
+	{
+		if (fourier_idx > 0){
+			//std::cout << " index low =  " << (fourier_idx - 1) << std::endl;
+			FFT_IDX2DIGFREQ(fourier_idx - 1, ZSIZE(VRiesz), freqL);
+		}
+		else{
+			freqL = sampling/(resolution + step);
+		}
+	}
+
 }
 
 
@@ -462,51 +603,115 @@ void ProgMonogenicSignalRes::run()
 	std::cout << "Looking for maximum frequency ..." << std::endl;
 	double criticalZ=icdf_gauss(significance);
 	double criticalW=-1;
-	double resolution, last_resolution = 10000;  //A huge value for achieving last_resolution < resolution
+	double resolution, resolution_2, last_resolution = 10000;  //A huge value for achieving
+												//last_resolution < resolution
 	double freq, freqH, freqL, resVal, counter;
 	double max_meanS = -1e38;
 	double cut_value = 0.025;
 
-	double range = maxRes-minRes;
 
-	double R_ = range/N_freq;
+//	Image<int> imgMask2;
+//	imgMask2 = mask;
+//	imgMask2.write("mascara_original.vol");
 
-	if (R_<0.1)
-		R_=0.1;
+	double R_ = freq_step;
 
-	double w0 = sampling/maxRes;
-	double wF = sampling/minRes;
+	if (R_<0.25)
+		R_=0.25;
+
+	double w0, wF;
+	double Nyquist = 2*sampling;
+	if (minRes<2*sampling)
+		minRes = Nyquist;
+	if (automaticMode)
+		minRes = Nyquist;
+	else
+	{
+		w0 = sampling/maxRes;
+		wF = sampling/minRes;
+	}
 	double w=w0;
 	bool doNextIteration=true;
 	bool lefttrimming = false;
-	int iter=0;
+	int fourier_idx, last_fourier_idx = -1, fourier_idx_2;
+
+	//A first MonoRes estimation to get an accurate mask
+
+	double mean_Signal, mean_noise, thresholdFirstEstimation;
+
+	DIGFREQ2FFT_IDX((maxRes+3)/sampling, ZSIZE(VRiesz), fourier_idx);
+
+	FFT_IDX2DIGFREQ(fourier_idx, ZSIZE(VRiesz), freq);
+	FFT_IDX2DIGFREQ(fourier_idx + 2, ZSIZE(VRiesz), freqH);
+	FFT_IDX2DIGFREQ(fourier_idx - 2, ZSIZE(VRiesz), freqL);
+
+	//std::cout << " freq = " << freq << " freqH = " << freqH << " freqL= " << freq <<std::endl;
+
 	int count_res = 0;
+	FileName fnDebug;
+
+	firstMonoResEstimation(fftV, freq, freqH, freqL, amplitudeMS,
+			count_res, fnDebug, mean_Signal, mean_noise, thresholdFirstEstimation);
+
+	//refining the mask
+//	std::cout << "mean_Signal = " << mean_Signal << std::endl;
+	NVoxelsOriginalMask = 0;
+	FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
+	{
+		if (DIRECT_MULTIDIM_ELEM(pMask, n) >=1)
+		{
+			if (DIRECT_MULTIDIM_ELEM(amplitudeMS, n)<thresholdFirstEstimation)
+			{
+				DIRECT_MULTIDIM_ELEM(pMask, n) = 0;
+			}
+			else
+			{
+				++NVoxelsOriginalMask;
+			}
+		}
+	}
+
+//	imgMask2 = mask;
+//	imgMask2.write("mascara_refinada.vol");
+
+	int iter=0;
 	std::vector<double> list;
 
 	std::cout << "Analyzing frequencies" << std::endl;
 	std::vector<double> noiseValues;
-	FileName fnDebug;
+
 	do
 	{
-		resolution = maxRes - count_res*R_;
-		freqL = sampling/(resolution+R_);
-		freq = sampling/resolution;
-		freqH = sampling/(resolution-R_);
-		if (freq > 0.5)
-		{
-		  std::cout << "search stopped due to Nyquist limit has been reached" << std::endl;
-		  break;
-		}
-		++count_res;
-		if (count_res<=2)
-			counter = 0; //maxRes/R_;
-		else
-			counter = 2;//count_res-2;
 
-		std::cout << "Iteration " << iter << " Freq = " << freq << " Resolution = " << resolution << " (A)" << std::endl;
-		//std::cout << "             " << " FreqLOW = " << freqL << " FreqHIGH = " << freqH << std::endl;
+		bool continueIter = false;
+		bool breakIter = false;
+
+		resolution2eval(count_res, R_,
+						resolution, last_resolution,
+						freq, freqH,
+						last_fourier_idx, continueIter, breakIter, doNextIteration);
+
+		if (continueIter)
+			continue;
+
+		if (breakIter)
+			break;
+
+		std::cout << "resolution = " << resolution << std::endl;
+
+
+		list.push_back(resolution);
+
+		if (iter <2)
+			resolution_2 = list[0];
+		else
+			resolution_2 = list[iter - 2];
 
 		fnDebug = "Signal";
+
+		freqL = freq + 0.01;
+//		if (freqL>=0.5)
+//			freqL = 0.5;
 
 		amplitudeMonogenicSignal3D(fftV, freq, freqH, freqL, amplitudeMS, iter, fnDebug);
 		if (halfMapsGiven)
@@ -515,7 +720,6 @@ void ProgMonogenicSignalRes::run()
 			amplitudeMonogenicSignal3D(*fftN, freq, freqH, freqL, amplitudeMN, iter, fnDebug);
 		}
 
-		list.push_back(freq);
 
 		double sumS=0, sumS2=0, sumN=0, sumN2=0, NN = 0, NS = 0;
 		noiseValues.clear();
@@ -526,10 +730,10 @@ void ProgMonogenicSignalRes::run()
 			{
 				FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
 				{
-					double amplitudeValue=DIRECT_MULTIDIM_ELEM(amplitudeMS, n);
-					double amplitudeValueN=DIRECT_MULTIDIM_ELEM(amplitudeMN, n);
 					if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
 					{
+						double amplitudeValue=DIRECT_MULTIDIM_ELEM(amplitudeMS, n);
+						double amplitudeValueN=DIRECT_MULTIDIM_ELEM(amplitudeMN, n);
 						sumS  += amplitudeValue;
 						sumS2 += amplitudeValue*amplitudeValue;
 						noiseValues.push_back(amplitudeValueN);
@@ -630,118 +834,174 @@ void ProgMonogenicSignalRes::run()
 		std::cout << "NS/NVoxelsOriginalMask = " << NS/NVoxelsOriginalMask << std::endl;
 		#endif
 		
-		
+//		std::cout << "NS = " << NS << "  NVoxelsOriginalMask" << NVoxelsOriginalMask << std::endl;
 		if ( (NS/NVoxelsOriginalMask)<cut_value ) //when the 2.5% is reached then the iterative process stops
 		{
-		  std::cout << "Search of resolutions stopped due to mask has been completed" << std::endl;
-		  doNextIteration =false;
-		Nvoxels = 0;
-		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
-		{
-		  if (DIRECT_MULTIDIM_ELEM(pOutputResolution, n) == 0)
-		    DIRECT_MULTIDIM_ELEM(pMask, n) = 0;
-		  else
-		  {
-		    Nvoxels++;
-		    DIRECT_MULTIDIM_ELEM(pMask, n) = 1;
-//		    if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
-//		    {
-//		      DIRECT_MULTIDIM_ELEM(pMask, n) = 0;
-//		    }
-//		    else
-//		      DIRECT_MULTIDIM_ELEM(pMask, n) = 1;
-		  }
-		}
-		#ifdef DEBUG_MASK
-		mask.write("partial_mask.vol");
-		#endif
-		lefttrimming = true;
-		}
-		else
-		{
-		
-		if (NS == 0)
-		{
-			std::cout << "There are no points to compute inside the mask" << std::endl;
-			std::cout << "If the number of computed frequencies is low, perhaps the provided"
-					"mask is not enough tight to the volume, in that case please try another mask" << std::endl;
-			break;
-		}
+			std::cout << "Search of resolutions stopped due to mask has been completed" << std::endl;
+			doNextIteration =false;
+			Nvoxels = 0;
 
-		double meanS=sumS/NS;
-		double sigma2S=sumS2/NS-meanS*meanS;
-		double meanN=sumN/NN;
-		double sigma2N=sumN2/NN-meanN*meanN;
-
-		if (meanS>max_meanS)
-			max_meanS = meanS;
-
-		if (meanS<0.001*max_meanS)
-		{
-			std::cout << "Search of resolutions stopped due to too low signal" << std::endl;
-			break;
-		}
-
-		// Check local resolution
-		double thresholdNoise;
-		if (exactres)
-		{
-			std::sort(noiseValues.begin(),noiseValues.end());
-			thresholdNoise = noiseValues[size_t(noiseValues.size()*significance)];
-		}
-		else
-			thresholdNoise = meanN+criticalZ*sqrt(sigma2N);
-
-		#ifdef DEBUG
-		  std::cout << "Iteration = " << iter << ",   Resolution= " << resolution << ",   Signal = " << meanS << ",   Noise = " << meanN << ",  Threshold = " << thresholdNoise <<std::endl;
-		#endif
-
-		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
-		{
-			if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
-				if (DIRECT_MULTIDIM_ELEM(amplitudeMS, n)>thresholdNoise)
+			FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
+			{
+				if (DIRECT_MULTIDIM_ELEM(pOutputResolution, n) == 0)
+					DIRECT_MULTIDIM_ELEM(pMask, n) = 0;
+				else
 				{
+					Nvoxels++;
 					DIRECT_MULTIDIM_ELEM(pMask, n) = 1;
-					DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution;//sampling/freq;
-					if (fnSpatial!="")
-						DIRECT_MULTIDIM_ELEM(pVresolutionFiltered,n)=DIRECT_MULTIDIM_ELEM(pVfiltered,n);
 				}
-				else{
-				  
-					DIRECT_MULTIDIM_ELEM(pMask, n) = DIRECT_MULTIDIM_ELEM(pMask, n) + 1;
-					if (DIRECT_MULTIDIM_ELEM(pMask, n) >2)
+			}
+
+			#ifdef DEBUG_MASK
+			mask.write("partial_mask.vol");
+			#endif
+
+			lefttrimming = true;
+		}
+		else
+		{
+			if (NS == 0)
+			{
+				std::cout << "There are no points to compute inside the mask" << std::endl;
+				std::cout << "If the number of computed frequencies is low, perhaps the provided"
+						"mask is not enough tight to the volume, in that case please try another mask" << std::endl;
+				break;
+			}
+
+			double meanS=sumS/NS;
+			double sigma2S=sumS2/NS-meanS*meanS;
+			double meanN=sumN/NN;
+			double sigma2N=sumN2/NN-meanN*meanN;
+
+			// Check local resolution
+			double thresholdNoise;
+			if (exactres)
+			{
+				std::sort(noiseValues.begin(),noiseValues.end());
+				thresholdNoise = noiseValues[size_t(noiseValues.size()*significance)];
+			}
+			else
+				thresholdNoise = meanN+criticalZ*sqrt(sigma2N);
+
+			#ifdef DEBUG
+			  std::cout << "Iteration = " << iter << ",   Resolution= " << resolution <<
+					  ",   Signal = " << meanS << ",   Noise = " << meanN << ",  Threshold = "
+					  << thresholdNoise <<std::endl;
+			#endif
+
+			double z=(meanS-meanN)/sqrt(sigma2S/NS+sigma2N/NN);
+
+//			std::cout << "z = " << z << "  zcritical = " << criticalZ << std::endl;
+
+			if (automaticMode)
+			{
+				if (z>criticalZ)
+				{
+//					std::cout << "z<criticalZ---->ENTRO" <<std::endl;
+
+					// Check local resolution
+					double thresholdNoise;
+					if (exactres)
 					{
-						DIRECT_MULTIDIM_ELEM(pMask, n) = -1;
-						DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution + counter*R_;//maxRes - counter*R_;
+						std::sort(noiseValues.begin(),noiseValues.end());
+						thresholdNoise = noiseValues[size_t(noiseValues.size()*significance)];
+					}
+					else
+						thresholdNoise = meanN+criticalZ*sqrt(sigma2N);
+
+					#ifdef DEBUG
+					  std::cout << "Iteration = " << iter << ",   Resolution= " << resolution <<
+							  ",   Signal = " << meanS << ",   Noise = " << meanN << ",  Threshold = "
+							  << thresholdNoise <<std::endl;
+					#endif
+					double NRES=0;
+					FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
+					{
+						if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
+							if (DIRECT_MULTIDIM_ELEM(amplitudeMS, n)<thresholdNoise)
+							{
+								DIRECT_MULTIDIM_ELEM(pMask, n) = 1;
+								DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution;//sampling/freq;
+								if (fnSpatial!="")
+									DIRECT_MULTIDIM_ELEM(pVresolutionFiltered,n)=DIRECT_MULTIDIM_ELEM(pVfiltered,n);
+							}
+							else{
+								++NRES;
+								DIRECT_MULTIDIM_ELEM(pMask, n) += 1;
+								if (DIRECT_MULTIDIM_ELEM(pMask, n) >2)
+								{
+									DIRECT_MULTIDIM_ELEM(pMask, n) = -1;
+									DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution_2;//maxRes - counter*R_;
+								}
+							}
+					}
+//					std::cout << " NRES" << NRES << std::endl;
+					if ( ( NRES/((double)NVoxelsOriginalMask) ) > 0.8 )
+					{
+						std::cout << " entroooo" << std::endl;
+						mask.read(fnMask);
 					}
 				}
-		}
-		#ifdef DEBUG_MASK
-		FileName fnmask_debug;
-		fnmask_debug = formatString("maske_%i.vol", iter);
-		mask.write(fnmask_debug);
-		#endif
+			}
+			else
+			{
+				if (meanS>max_meanS)
+					max_meanS = meanS;
 
-		// Is the mean inside the signal significantly different from the noise?
-		double z=(meanS-meanN)/sqrt(sigma2S/NS+sigma2N/NN);
-		#ifdef DEBUG
-			std::cout << "thresholdNoise = " << thresholdNoise << std::endl;
-			std::cout << "  meanS= " << meanS << " sigma2S= " << sigma2S << " NS= " << NS << std::endl;
-			std::cout << "  meanN= " << meanN << " sigma2N= " << sigma2N << " NN= " << NN << std::endl;
-			std::cout << "  z=" << z << " (" << criticalZ << ")" << std::endl;
-		#endif
-		if (z<criticalZ)
-		{
-			criticalW = freq;
-			doNextIteration=false;
-		}
-		if (doNextIteration)
-		{
-			if (resolution <= (minRes-0.001))
-				doNextIteration = false;
-		}
+				if (meanS<0.001*max_meanS)
+				{
+					std::cout << "Search of resolutions stopped due to too low signal" << std::endl;
+					break;
+				}
+
+				FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(amplitudeMS)
+				{
+					if (DIRECT_MULTIDIM_ELEM(pMask, n)>=1)
+						if (DIRECT_MULTIDIM_ELEM(amplitudeMS, n)>thresholdNoise)
+						{
+							DIRECT_MULTIDIM_ELEM(pMask, n) = 1;
+							DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution;//sampling/freq;
+							if (fnSpatial!="")
+								DIRECT_MULTIDIM_ELEM(pVresolutionFiltered,n)=DIRECT_MULTIDIM_ELEM(pVfiltered,n);
+						}
+						else{
+							DIRECT_MULTIDIM_ELEM(pMask, n) += 1;
+							if (DIRECT_MULTIDIM_ELEM(pMask, n) >2)
+							{
+								DIRECT_MULTIDIM_ELEM(pMask, n) = -1;
+								DIRECT_MULTIDIM_ELEM(pOutputResolution, n) = resolution_2;//maxRes - counter*R_;
+							}
+						}
+				}
+				#ifdef DEBUG_MASK
+				FileName fnmask_debug;
+				fnmask_debug = formatString("maske_%i.vol", iter);
+				mask.write(fnmask_debug);
+				#endif
+
+				// Is the mean inside the signal significantly different from the noise?
+				z=(meanS-meanN)/sqrt(sigma2S/NS+sigma2N/NN);
+				#ifdef DEBUG
+					std::cout << "thresholdNoise = " << thresholdNoise << std::endl;
+					std::cout << "  meanS= " << meanS << " sigma2S= " << sigma2S << " NS= " << NS << std::endl;
+					std::cout << "  meanN= " << meanN << " sigma2N= " << sigma2N << " NN= " << NN << std::endl;
+					std::cout << "  z=" << z << " (" << criticalZ << ")" << std::endl;
+				#endif
+				if (z<criticalZ)
+				{
+					criticalW = freq;
+					std::cout << "Search stopped due to z>Z (hypothesis test)" << std::endl;
+					doNextIteration=false;
+				}
+				if (doNextIteration)
+				{
+					if (resolution <= (minRes-0.001))
+						doNextIteration = false;
+				}
+			}
 		}
 		iter++;
+		last_resolution = resolution;
 	} while (doNextIteration);
 
 	if (lefttrimming == false)

--- a/software/em/xmipp/libraries/reconstruction/resolution_monogenic_signal.h
+++ b/software/em/xmipp/libraries/reconstruction/resolution_monogenic_signal.h
@@ -50,19 +50,20 @@ class ProgMonogenicSignalRes : public XmippProgram
 {
 public:
 	 /** Filenames */
-	FileName fnOut, fnVol, fnVol2, fnMask, fnchim, fnSpatial, fnSym, fnMeanVol, fnMaskOut, fnMd;
+	FileName fnOut, fnVol, fnVol2, fnMask, fnchim, fnSpatial, fnSym,
+	fnMeanVol, fnMaskOut, fnMd;
 
 	/** sampling rate, minimum resolution, and maximum resolution */
 	double sampling, minRes, maxRes, R;
 
 	/** Is the volume previously masked?*/
-	int NVoxelsOriginalMask, Nvoxels;
+	int NVoxelsOriginalMask, Nvoxels, nthrs;
 
 	/** Step in digital frequency */
-	double N_freq, trimBound, significance;
+	double freq_step, trimBound, significance;
 
 	/** The search for resolutions is linear or inverse**/
-	bool exactres, noiseOnlyInHalves;
+	bool exactres, noiseOnlyInHalves, automaticMode;
 
 public:
 
@@ -73,10 +74,21 @@ public:
     /* Mogonogenid amplitud of a volume, given an input volume,
      * the monogenic amplitud is calculated and low pass filtered at frequency w1*/
     void amplitudeMonogenicSignal3D(MultidimArray< std::complex<double> > &myfftV,
-    		double w1, double w1l, double w1h, MultidimArray<double> &amplitude,
+    		double freq, double freqH, double freqL, MultidimArray<double> &amplitude,
     		int count, FileName fnDebug);
+    void firstMonoResEstimation(MultidimArray< std::complex<double> > &myfftV,
+    		double freq, double freqH, double freqL, MultidimArray<double> &amplitude,
+    		int count, FileName fnDebug, double &mean_Signal,
+			double &mean_noise, double &thresholdFirstEstimation);
     void postProcessingLocalResolutions(MultidimArray<double> &resolutionVol,
-    		std::vector<double> &list, MultidimArray<double> &resolutionChimera, double &cut_value, MultidimArray<int> &pMask);
+    		std::vector<double> &list, MultidimArray<double> &resolutionChimera,
+    		double &cut_value, MultidimArray<int> &pMask);
+    void resolution2eval(int &count_res, double step,
+    								double &resolution, double &last_resolution,
+    								double &freq, double &freqL,
+    								int &last_fourier_idx,
+    								bool &continueIter,	bool &breakIter,
+    								bool &doNextIteration);
     void run();
 
 public:
@@ -84,10 +96,12 @@ public:
     MultidimArray<double> iu, VRiesz; // Inverse of the frequency
 	MultidimArray< std::complex<double> > fftV, *fftN; // Fourier transform of the input volume
 	FourierTransformer transformer_inv;
-	MultidimArray< std::complex<double> > fftVRiesz;
+	MultidimArray< std::complex<double> > fftVRiesz, fftVRiesz_aux;
 	FourierFilter lowPassFilter, FilterBand;
 	bool halfMapsGiven;
 	Image<double> Vfiltered, VresolutionFiltered;
+	Matrix1D<double> freq_fourier;
+	Matrix2D<double> resolutionMatrix, maskMatrix;
 };
 //@}
 #endif


### PR DESCRIPTION
This allows to load project.sqlite when there's nothing else. This allows to load them even in the cases where some outputsets where required and missing.

closes #1597 