### PR TITLE
Some fixes for https://github.com/I2PC/scipion/issues/1610

### DIFF
--- a/pyworkflow/em/packages/grigoriefflab/protocol_unblur.py
+++ b/pyworkflow/em/packages/grigoriefflab/protocol_unblur.py
@@ -466,6 +466,7 @@ eof
         first, _ = self._getFrameRange(movie.getNumberOfFrames(), 'align')
         plotter = createGlobalAlignmentPlot(shiftsX, shiftsY, first)
         plotter.savefig(self._getPlotGlobal(movie))
+        plotter.close()
 
 def createGlobalAlignmentPlot(meanX, meanY, first):
     """ Create a plotter with the shift per frame. """

--- a/pyworkflow/em/packages/ispyb/protocol_monitor_ispyb.py
+++ b/pyworkflow/em/packages/ispyb/protocol_monitor_ispyb.py
@@ -232,6 +232,7 @@ def _saveAlignmentPlots(self, movie):
     meanX, meanY = self._loadMeanShifts(movie)
     plotter = createAlignmentPlot(meanX, meanY)
     plotter.savefig(self._getPlotCart(movie))
+    plotter.close()
 
 
 def createAlignmentPlot(meanX, meanY):

--- a/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
+++ b/pyworkflow/em/packages/motioncorr/protocol_motioncorr.py
@@ -594,6 +594,7 @@ class ProtMotionCorr(ProtAlignMovies):
         first, _ = self._getFrameRange(movie.getNumberOfFrames(), 'align')
         plotter = createGlobalAlignmentPlot(shiftsX, shiftsY, first)
         plotter.savefig(self._getPlotGlobal(movie))
+        plotter.close()
 
     def _isOutStackSupport(self):
         # checks if output aligned movies can be saved by motioncor2

--- a/pyworkflow/em/packages/xmipp3/protocol_movie_correlation.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_movie_correlation.py
@@ -227,6 +227,7 @@ class XmippProtMovieCorr(ProtAlignMovies):
         meanX, meanY = self._loadMeanShifts(movie)
         plotter = createAlignmentPlot(meanX, meanY)
         plotter.savefig(self._getPlotCart(movie))
+        plotter.close()
 
     def _setAlignmentInfo(self, movie, obj):
         """ Set alignment info such as plot and psd filename, and

--- a/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_movie_opticalflow.py
@@ -353,6 +353,7 @@ class XmippProtOFAlignment(ProtAlignMovies):
         meanX, meanY = self._loadMeanShifts(movie)
         plotter = createAlignmentPlot(meanX, meanY)
         plotter.savefig(self._getPlotCart(movie))
+        plotter.close()
 
     def _createOutputMicrographs(self):
         createWeighted = self._createOutputWeightedMicrographs()

--- a/pyworkflow/em/packages/xmipp3/protocol_rotational_spectra.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_rotational_spectra.py
@@ -193,6 +193,7 @@ class XmippProtRotSpectra(KendersomBaseClassify):
         
         plotFile = join(self.plotsDir, 'spectra_%s%06d.png' % (label, objId))
         plotter.savefig(plotFile)
+        plotter.close()
         
         return plotFile
         

--- a/pyworkflow/web/app/wizards/resmap_wizard.py
+++ b/pyworkflow/web/app/wizards/resmap_wizard.py
@@ -159,8 +159,8 @@ def getPlotResMap(request, protocol):
     plotter = _runPreWhiteningWeb(protocol, results)
     #3rd step: Save to png image
     
-#     plotUrl = "/" + savePlot(request, plotter)
-    plotUrl = savePlot(request, plotter) 
+    plotUrl = savePlot(request, plotter)
+    plotter.close()
     return plotUrl, min_ang
 
 def _beforePreWhitening(protocol, dir):


### PR DESCRIPTION
In any instance where
- The `Figure` instance is created locally
- `savefig` is called
and
- The `Figure` is not returned from the function

It should be safe to immediately call .close() on the Figure instance.

There are still `savefig` calls that may be easy corrections in:
- pyworkflow/em/packages/xmipp3/protocol_multireference_alignability.py - I think the reference is supposed to be retained here?
- pyworkflow/em/packages/resmap/protocol_resmap.py - I'm not sure about this one
- pyworkflow/web/app/views_util.py - plotter passed in externally (fixed one instance I think safely, but pyworkflow/web/app/em_viewer.py is still using with a view call that I’m not familiar with the implications of)

This implemented as a test fix for #1610 results in no leak (image below shows ~1600 movies processed using the same set of protocols as in the original issue, but now without any of the accumulation that we saw before).

<img width="1310" alt="screen shot 2018-05-20 at 4 41 02 pm" src="https://user-images.githubusercontent.com/4432140/40284061-ef494c7e-5c56-11e8-8ea3-3a0905c72850.png">
