### PR TITLE
Release 1.2.1 relion fixes

### DIFF
--- a/pyworkflow/em/packages/relion/protocol_autopick_v2.py
+++ b/pyworkflow/em/packages/relion/protocol_autopick_v2.py
@@ -369,6 +369,20 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
             writeReferences(self.getInputReferences(),
                             self._getPath('input_references'), useBasename=True)
 
+        # FIXME: (JMRT-20180523) The following code does not seems to work
+        # here it has been worked around by changing the name of the wizard
+        # output but this seems to reflect a deeper problem of deleting
+        # already existing output objects in a protocol. Maybe when updating
+        # from run.db to project.sqlite?
+
+        # Clean up if previously created the outputMicrographs and Coordinates
+        # in the wizard - optimization run
+        # if self.hasAttribute('outputMicrographs'):
+        #     self._deleteChild('outputMicrographs', self.outputMicrographs)
+        # if self.hasAttribute('outputCoordinates'):
+        #     self._deleteChild('outputCoordinates', self.outputCoordinates)
+        # self._store()
+
     def getAutopickParams(self):
         # Return the autopicking parameters except for the interative ones:
         # - threshold
@@ -474,6 +488,7 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
 
     def createOutputStep(self):
         micSet = self.getInputMicrographs()
+        outputCoordinatesName = 'outputCoordinates'
 
         # If in optimization phase, let's create a subset of the micrographs
         if self.isRunOptimize():
@@ -481,14 +496,11 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
             micSubSet.copyInfo(micSet)
             for mic in self.getMicrographList():
                 micSubSet.append(mic)
-            self._defineOutputs(outputMicrographs=micSubSet)
+            self._defineOutputs(outputMicrographsSubset=micSubSet)
             self._defineTransformRelation(self.getInputMicrographsPointer(),
                                           micSubSet)
             micSet = micSubSet
-        else:
-            # Clean up if previously created the outputMicrographs
-            if self.hasAttribute('outputMicrographs'):
-                self._deleteChild('outputMicrographs', self.outputMicrographs)
+            outputCoordinatesName = 'outputCoordinatesSubset'
 
         coordSet = self._createSetOfCoordinates(micSet)
         template = self._getExtraPath("%s_autopick.star")
@@ -496,7 +508,7 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
                      for mic in micSet]
         readSetOfCoordinates(coordSet, starFiles, micSet)
 
-        self._defineOutputs(outputCoordinates=coordSet)
+        self._defineOutputs(**{outputCoordinatesName: coordSet})
         self._defineSourceRelation(self.getInputMicrographsPointer(),
                                    coordSet)
 
@@ -690,7 +702,6 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
         #     img.setCTF(self.ctfDict[img.getMicName()])
 
     def _postprocessMicrographRow(self, img, imgRow):
-        print "Writing md to: ", self._getMicStarFile(img)
         imgRow.writeToFile(self._getMicStarFile(img))
 
     def _getMicStarFile(self, mic):

--- a/pyworkflow/em/packages/relion/protocol_autopick_v2.py
+++ b/pyworkflow/em/packages/relion/protocol_autopick_v2.py
@@ -497,7 +497,9 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
             outputCoordinatesName = 'outputCoordinatesSubset'
             micSubSet = self._createSetOfMicrographs(suffix=outputSuffix)
             micSubSet.copyInfo(micSet)
-            for mic in self.getMicrographList():
+            # Use previously written star file for reading the subset of micrographs,
+            for row in md.iterRows(self._getPath('input_micrographs.star')):
+                mic = micSet[row.getValue('rlnImageId')]
                 micSubSet.append(mic)
             self._defineOutputs(outputMicrographsSubset=micSubSet)
             self._defineTransformRelation(self.getInputMicrographsPointer(),

--- a/pyworkflow/em/packages/relion/protocol_autopick_v2.py
+++ b/pyworkflow/em/packages/relion/protocol_autopick_v2.py
@@ -489,10 +489,13 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
     def createOutputStep(self):
         micSet = self.getInputMicrographs()
         outputCoordinatesName = 'outputCoordinates'
+        outputSuffix = ''
 
         # If in optimization phase, let's create a subset of the micrographs
         if self.isRunOptimize():
-            micSubSet = self._createSetOfMicrographs()
+            outputSuffix = '_subset'
+            outputCoordinatesName = 'outputCoordinatesSubset'
+            micSubSet = self._createSetOfMicrographs(suffix=outputSuffix)
             micSubSet.copyInfo(micSet)
             for mic in self.getMicrographList():
                 micSubSet.append(mic)
@@ -500,7 +503,6 @@ class ProtRelion2Autopick(ProtParticlePickingAuto, ProtRelionBase):
             self._defineTransformRelation(self.getInputMicrographsPointer(),
                                           micSubSet)
             micSet = micSubSet
-            outputCoordinatesName = 'outputCoordinatesSubset'
 
         coordSet = self._createSetOfCoordinates(micSet)
         template = self._getExtraPath("%s_autopick.star")

--- a/pyworkflow/em/packages/relion/wizard.py
+++ b/pyworkflow/em/packages/relion/wizard.py
@@ -251,13 +251,13 @@ class Relion2AutopickParams(EmWizard):
     def show(self, form):
         autopickProt = form.protocol
 
-        if not autopickProt.hasAttribute('outputCoordinates'):
+        if not autopickProt.hasAttribute('outputCoordinatesSubset'):
             form.showWarning("You should run the procotol in 'Optimize' mode "
                                "at least once before opening the wizard.")
             return
 
         project = autopickProt.getProject()
-        micSet = autopickProt.outputMicrographs
+        micSet = autopickProt.outputMicrographsSubset
         micfn = micSet.getFileName()
         coordsDir = project.getTmpPath(micSet.getName())
         cleanPath(coordsDir)

--- a/pyworkflow/em/packages/xmipp3/convert.py
+++ b/pyworkflow/em/packages/xmipp3/convert.py
@@ -525,6 +525,12 @@ def rowToCoordinate(coordRow):
 
 def _rowToParticle(partRow, particleClass, **kwargs):
     """ Create a Particle from a row of a metadata. """
+    # Since postprocessImage is intended to be after the object is
+    # setup, we need to intercept it here and call it at the end
+    postprocessImageRow = kwargs.get('postprocessImageRow', None)
+    if postprocessImageRow:
+        del kwargs['postprocessImageRow']
+
     img = rowToImage(partRow, xmipp.MDL_IMAGE, particleClass, **kwargs)
     img.setCoordinate(rowToCoordinate(partRow))
     # copy micId if available
@@ -542,7 +548,11 @@ def _rowToParticle(partRow, particleClass, **kwargs):
 #        else:
 #            print "WARNING: No micname"
     except Exception as e:
-        print "Warning:", e.message
+        print("Warning:", e.message)
+
+    if postprocessImageRow:
+        postprocessImageRow(img, partRow)
+
     return img
 
 

--- a/pyworkflow/em/packages/xmipp3/protocol_extract_particles_movies.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_extract_particles_movies.py
@@ -158,7 +158,8 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
                       expertLevel=LEVEL_ADVANCED)
 
         form.addParallelSection(threads=3, mpi=1)
-    #--------------------------- INSERT steps functions ------------------------
+
+    # ------------------------- INSERT steps functions ------------------------
 
     def _insertAllSteps(self):
         self._createFilenameTemplates()
@@ -324,8 +325,11 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
 #         makePath(particleFolder)
         mData = md.MetaData()
         mdAll = md.MetaData()
-          
+
+        self._micNameDict = {}
+
         for movie in inputMovies:
+            self._micNameDict[movie.getObjId()] = movie.getMicName()
             movieName = self._getMovieName(movie)
             movieStk = movieName.replace('.mrc', '.stk')
             movieMdFile = movieName.replace('.mrc', '.xmd')
@@ -344,7 +348,7 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
         self._defineOutputs(outputParticles=particleSet)
         self._defineSourceRelation(self.inputMovies, particleSet)
     
-    # --------------------------- INFO functions -------------------------------
+    # --------------------------- INFO functions ------------------------------
     def _validate(self):
         errors = []
         
@@ -401,7 +405,8 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
         summary = []
         return summary
     
-    #--------------------------- UTILS functions -------------------------------
+    # -------------------------- UTILS functions ------------------------------
+
     def _getFnRelated(self, keyFile, movId, frameIndex):
         return self._getFileName(keyFile, movieId=movId, frame=frameIndex)
     
@@ -443,7 +448,8 @@ class XmippProtExtractMovieParticles(ProtExtractMovieParticles):
     def _postprocessImageRow(self, img, imgRow):
         img.setFrameId(imgRow.getValue(md.MDL_FRAME_ID))
         img.setParticleId(imgRow.getValue(md.MDL_PARTICLE_ID))
-
+        micName = self._micNameDict[imgRow.getValue(md.MDL_MICROGRAPH_ID)]
+        img.getCoordinate().setMicName(micName)
 
     def _useAlignToSum(self):
         return self.getAttributeValue('useAlignToSum', False)

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -510,8 +510,9 @@ class RelationsTreeProvider(SubclassesTreeProvider):
         objects = []
         if self.item is not None:
             project = self.protocol.getProject()
-            for pobj in project.getRelatedObjects(self.relationParam.getName(), 
-                                                 self.item, self.direction):
+            for pobj in project.getRelatedObjects(self.relationParam.getName(),
+                                                  self.item, self.direction,
+                                                  refresh=True):
                 objects.append(pobj.clone())
 
         # Sort objects

--- a/pyworkflow/project.py
+++ b/pyworkflow/project.py
@@ -1268,7 +1268,8 @@ class Project(object):
 
         return self._sourceGraph
 
-    def getRelatedObjects(self, relation, obj, direction=em.RELATION_CHILDS):
+    def getRelatedObjects(self, relation, obj, direction=em.RELATION_CHILDS,
+                          refresh=False):
         """ Get all objects related to obj by a give relation.
         Params:
             relation: the relation name to search for.
@@ -1277,7 +1278,7 @@ class Project(object):
                 to this one by the RELATION_TRANSFORM.
             direction: this say if search for childs or parents in the relation.
         """
-        graph = self.getTransformGraph()
+        graph = self.getTransformGraph(refresh)
         relations = self.mapper.getRelationsByName(relation)
         connection = self._getConnectedObjects(obj, graph)
 


### PR DESCRIPTION
* Fixed bug when using Relion picking: the run of the protocol for optimize the picking params was generating a set of micrographs (subset based on defocus) and a set of coordinates (linked to the subset), but when executing for the whole set, still the output coordinates was there and with bad reference to microgasph!!! Solution: change the name to 'outputXXXSubset'. Still, it seems to be a deeper problem with deleting outputs of a protocol in a Continue mode.
* Alleviated the problem of selecting input CTF and getting no input in the select dialog...now a refresh param is passed as True and it seems to be less problematic now, not sure if will pick up the inputs immediately. The downside is that it takes a bit more of time when opening, but I think is a good price to pay for avoiding the annoyance of not finding any input CTF. 
