### PR TITLE
Add a threshold in phantom_simulate_microscope Test

### DIFF
--- a/pyworkflow/tests/em/programs/test_programs_xmipp.py
+++ b/pyworkflow/tests/em/programs/test_programs_xmipp.py
@@ -783,7 +783,7 @@ class PhantomSimulateMicroscope(XmippProgramTest):
 
     def test_case1(self):
         self.runCase("-i input/projectionsBacteriorhodopsin.stk -o %o/smallStackPlusCtf.stk --ctf input/input.ctfparam --noNoise",
-                outputs=["smallStackPlusCtf.stk"])
+                outputs=["smallStackPlusCtf.stk"],errorthreshold=0.05)
     def test_case2(self):
         self.runCase("-i input/projectionsBacteriorhodopsin.stk -o %o/smallStackPlusCtf.stk --ctf input/input.ctfparam --targetSNR 0.3",
                 outputs=["smallStackPlusCtf.stk"],random=True)


### PR DESCRIPTION
The threshold for the assertion in the phantomSimulateMicroscope test has been increased in order to pass in different branches where the approach has been slightly changed.