### PR TITLE
Xmipp CTF estimation with VPP issues fixed and self estimation defocus

### DIFF
--- a/install/script.py
+++ b/install/script.py
@@ -202,7 +202,7 @@ python = env.addLibrary(
     'python',
     tar='Python-2.7.14.tgz',
     targets=[env.getLib('python2.7'), env.getBin('python')],
-    flags=['--enable-shared'],
+    flags=['--enable-shared','--enable-unicode=ucs4'],
     deps=[sqlite, tk, zlib])
 
 pcre = env.addLibrary(

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -122,7 +122,8 @@ class CTFModel(EMObject):
         self._defocusV = Float(kwargs.get('defocusV', None))
         self._defocusAngle = Float(kwargs.get('defocusAngle', None))
         self._defocusRatio = Float()
-        self._phaseShift = Float(kwargs.get('phaseShift', None))
+        self._phaseShift = None if not 'phaseShift' in kwargs \
+                           else Float(kwargs.get('phaseShift', None))
         self._defocusRatio = Float()
         self._psdFile = String()
         self._micObj = None

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -122,8 +122,7 @@ class CTFModel(EMObject):
         self._defocusV = Float(kwargs.get('defocusV', None))
         self._defocusAngle = Float(kwargs.get('defocusAngle', None))
         self._defocusRatio = Float()
-        self._phaseShift = None if not 'phaseShift' in kwargs \
-                           else Float(kwargs.get('phaseShift', None))
+        self._phaseShift = Float(kwargs['phaseShift']) if 'phaseShift' in kwargs else None
         self._defocusRatio = Float()
         self._psdFile = String()
         self._micObj = None

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -122,8 +122,7 @@ class CTFModel(EMObject):
         self._defocusV = Float(kwargs.get('defocusV', None))
         self._defocusAngle = Float(kwargs.get('defocusAngle', None))
         self._defocusRatio = Float()
-        self._phaseShift = None if not 'phaseShift' in kwargs \
-            else Float(kwargs.get('phaseShift', None))
+        self._phaseShift = Float(kwargs.get('phaseShift', None))
         self._defocusRatio = Float()
         self._psdFile = String()
         self._micObj = None

--- a/pyworkflow/em/packages/xmipp3/convert.py
+++ b/pyworkflow/em/packages/xmipp3/convert.py
@@ -653,7 +653,7 @@ def rowToCtfModel(ctfRow):
         ctfModel.standardize()
         # Set psd file names
         setPsdFiles(ctfModel, ctfRow)
-        ctfModel.setPhaseShift(0.0)  # for consistency with ctfModel
+        #ctfModel.setPhaseShift(0.0)  # for consistency with ctfModel
 
     else:
         ctfModel = None

--- a/pyworkflow/em/packages/xmipp3/convert.py
+++ b/pyworkflow/em/packages/xmipp3/convert.py
@@ -642,6 +642,8 @@ def rowToCtfModel(ctfRow):
         # Case for metadata coming with Xmipp resolution label
         # Populate Scipion CTF from metadata row (using mapping dictionary
         # plus extra labels
+        if ctfRow.hasLabel(md.MDL_CTF_PHASE_SHIFT):
+            ctfModel.setPhaseShift(ctfRow.getValue(md.MDL_CTF_PHASE_SHIFT, 0))
         if ctfRow.containsLabel(xmipp.label2Str(xmipp.MDL_CTF_CRIT_MAXFREQ)):
             rowToObject(ctfRow, ctfModel, CTF_DICT,
                         extraLabels=CTF_EXTRA_LABELS)

--- a/pyworkflow/em/packages/xmipp3/convert.py
+++ b/pyworkflow/em/packages/xmipp3/convert.py
@@ -607,8 +607,11 @@ def ctfModelToRow(ctfModel, ctfRow):
     """ Set labels values from ctfModel to md row. """
     # TODO: compatibility check remove eventually
     if ctfModel.hasResolution():
+
         objectToRow(ctfModel, ctfRow, CTF_DICT,
                     extraLabels=CTF_EXTRA_LABELS)
+        if ctfModel.hasPhaseShift():
+            ctfRow.setValue(xmipp.MDL_CTF_PHASE_SHIFT, ctfModel.getPhaseShift())
     else:
         objectToRow(ctfModel, ctfRow, CTF_DICT_NORESOLUTION,
                     extraLabels=CTF_EXTRA_LABELS)
@@ -643,7 +646,9 @@ def rowToCtfModel(ctfRow):
         # Populate Scipion CTF from metadata row (using mapping dictionary
         # plus extra labels
         if ctfRow.hasLabel(md.MDL_CTF_PHASE_SHIFT):
-            ctfModel.setPhaseShift(ctfRow.getValue(md.MDL_CTF_PHASE_SHIFT, 0))
+
+            ctfModel.setPhaseShift(ctfRow.getValue(md.MDL_CTF_PHASE_SHIFT, 0.0))
+
         if ctfRow.containsLabel(xmipp.label2Str(xmipp.MDL_CTF_CRIT_MAXFREQ)):
             rowToObject(ctfRow, ctfModel, CTF_DICT,
                         extraLabels=CTF_EXTRA_LABELS)

--- a/pyworkflow/em/packages/xmipp3/convert.py
+++ b/pyworkflow/em/packages/xmipp3/convert.py
@@ -68,7 +68,7 @@ CTF_DICT = OrderedDict([
        ("_defocusU", xmipp.MDL_CTF_DEFOCUSU),
        ("_defocusV", xmipp.MDL_CTF_DEFOCUSV),
        ("_defocusAngle", xmipp.MDL_CTF_DEFOCUS_ANGLE),
-       ("_phaseShift", xmipp.MDL_CTF_PHASE_SHIFT),
+       #("_phaseShift", xmipp.MDL_CTF_PHASE_SHIFT),
        ("_resolution", xmipp.MDL_CTF_CRIT_MAXFREQ),
        ("_fitQuality", xmipp.MDL_CTF_CRIT_FITTINGSCORE)
        ])

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -55,11 +55,11 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
 
     _criterion_phaseplate = ("ctfCritFirstZero<5 OR ctfCritMaxFreq>20 OR "
                   "ctfCritfirstZeroRatio<0.9 OR ctfCritfirstZeroRatio>1.1 OR "
-                  "ctfCritFirstMinFirstZeroRatio>10 AND "
-                  "ctfCritFirstMinFirstZeroRatio!=1000 OR "
-                  "ctfCritNonAstigmaticValidty<0 OR ctfCritFitting>1 OR " 
+                  "ctfCritFirstMinFirstZeroRatio>12 AND "
+                  "ctfCritFirstMinFirstZeroRatio!=1000 OR ctfCritCorr13==0 OR "
+                  "ctfCritNonAstigmaticValidty<=0 OR ctfVPPphaseshift>140 OR " 
                   "ctfCritNonAstigmaticValidty>25 "
-                  "OR ctfCritIceness>1.01")  #OR ctfBgGaussian2SigmaU>70000 ctfCritCorr13==0 OR
+                  "OR ctfCritIceness>1.03")  #OR ctfBgGaussian2SigmaU>70000
 
     def __init__(self, **args):
 
@@ -138,7 +138,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
         
         if self.AutoDownsampling:
             if self.findPhaseShift:
-                ctfDownFactor = self.calculateAutodownsampling(samplingRate, 1.0)
+                ctfDownFactor = self.calculateAutodownsampling(samplingRate, 1.2)
             else:
                 ctfDownFactor = self.calculateAutodownsampling(samplingRate)
         else:
@@ -164,7 +164,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                 localParams['defocusU'], localParams['phaseShift0'] = \
                     self.ctfDict[micName]
                 if self.findPhaseShift:
-                    localParams['defocus_range'] = 0.15 * localParams['defocusU']
+                    localParams['defocus_range'] = 0.1 * localParams['defocusU']
                 else:
                     localParams['defocus_range'] = 0.1 * localParams['defocusU']
 
@@ -323,12 +323,8 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                 ctfName = ctf.getMicrograph().getMicName()
                 phaseShift0 = 0.0
                 if self.findPhaseShift:
-                    if ctf.hasPhaseShift(): #hasattr(ctf,"_phaseShift") and ctf._phaseShift.get() != None:
-                        phaseShift0=ctf.getPhaseShift()#_phaseShift.get()
-                        radians = phaseShift0/3.14
-                        if radians > 1 or flagDegrees == 1:
-                            flagDegrees == 1
-                            phaseShift0 = (phaseShift0*3.14)/180
+                    if ctf.hasPhaseShift():
+                        phaseShift0=ctf.getPhaseShift()
                     else:
                         phaseShift0 = 1.57079 # pi/2
                     self.ctfDict[ctfName] = (ctf.getDefocusU(),phaseShift0)

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -28,7 +28,6 @@
 
 import sys
 from os.path import join, exists, getmtime
-from datetime import datetime
 
 from pyworkflow.object import Set, String
 import pyworkflow.em as em
@@ -36,7 +35,6 @@ import pyworkflow.em.metadata as md
 import pyworkflow.protocol.params as params
 import pyworkflow.protocol.constants as pwconst
 import pyworkflow.utils as pwutils
-import time
 
 from pyworkflow.em.packages.xmipp3.utils import isMdEmpty
 from pyworkflow.em.packages.xmipp3.convert import mdToCTFModel, readCTFModel
@@ -138,7 +136,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
         
         if self.AutoDownsampling:
             if self.findPhaseShift:
-                ctfDownFactor = self.calculateAutodownsampling(samplingRate, 1.0)
+                ctfDownFactor = self.calculateAutodownsampling(samplingRate, 1.1)
             else:
                 ctfDownFactor = self.calculateAutodownsampling(samplingRate)
         else:

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -52,12 +52,12 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                   "ctfCritIceness>1")
 
     _criterion_phaseplate = ("ctfCritFirstZero<5 OR ctfCritMaxFreq>20 OR "
-                  "ctfCritfirstZeroRatio<0.9 OR ctfCritfirstZeroRatio>1.10 OR "
-                  "ctfCritFirstMinFirstZeroRatio>12 AND "
+                  "ctfCritfirstZeroRatio<0.9 OR ctfCritfirstZeroRatio>1.1 OR "
+                  "ctfCritFirstMinFirstZeroRatio>50 AND "
                   "ctfCritFirstMinFirstZeroRatio!=1000 OR ctfCritCorr13==0 OR "
                   "ctfCritNonAstigmaticValidty<=0 OR ctfVPPphaseshift>140 OR " 
                   "ctfCritNonAstigmaticValidty>25 "
-                  "OR ctfCritIceness>1.03")
+                  "OR ctfCritIceness>1.03") 
 
     def __init__(self, **args):
 
@@ -181,7 +181,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
         downsampleList=self._calculateDownsampleList(
             self.inputMics.getSamplingRate())
         deleteTmp = ""
-        self.downsample = 0
+        #self.downsample = 0
         for downFactor in downsampleList:
             # Downsample if necessary
             if downFactor != 1:
@@ -222,7 +222,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
                                      "failed with micrograph %s" % finalName
             # Check the quality of the estimation and reject it necessary
             good = self.evaluateSingleMicrograph(micFn, micDir)
-            self.downsample += 1
+            #self.downsample += 1
             if good:
                 break
 
@@ -461,7 +461,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
             Iceness = mdCTFparam.getValue(md.MDL_CTF_CRIT_ICENESS, 1)
             mdCTFparam.setValue(md.MDL_ENABLED, -1, mdCTFparam.firstObject())
             mdCTFparam.write(fnEval)
-            if Iceness > 1:
+            if Iceness > 1.03:
                 retval = True
              
         pwutils.path.cleanPath(fnRejected)

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -315,26 +315,24 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
             flagDegrees = 0
             for ctf in self.ctfRelations.get():
                 ctfName = ctf.getMicrograph().getMicName()
-                phaseShift0 = 0
+                phaseShift0 = 0.0
                 if self.findPhaseShift:
-                    if hasattr(ctf,"_phaseShift") and ctf._phaseShift.get() != None:
-                        phaseShift0=ctf._phaseShift.get()
+                    if ctf.hasPhaseShift(): #hasattr(ctf,"_phaseShift") and ctf._phaseShift.get() != None:
+                        phaseShift0=ctf.getPhaseShift()#_phaseShift.get()
                         radians = phaseShift0/3.14
                         if radians > 1 or flagDegrees == 1:
                             flagDegrees == 1
                             phaseShift0 = (phaseShift0*3.14)/180
-
                     else:
                         phaseShift0 = 1.57079 # pi/2
                     self.ctfDict[ctfName] = (ctf.getDefocusU(),phaseShift0)
                 else:
                     self.ctfDict[ctfName] = (ctf.getDefocusU(), phaseShift0)
+
         if self.findPhaseShift and not self.ctfRelations.hasValue():
             self._params['phaseShift0'] = 1.57079
 
     def _prepareCommand(self):
-        # phase_shift0 does not work
-        # with self.ctfRelations.hasValue()
         if not hasattr(self, "ctfDict") and self.ctfRelations.hasValue():
             self.getPreviousParameters()
 

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -55,11 +55,11 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
 
     _criterion_phaseplate = ("ctfCritFirstZero<5 OR ctfCritMaxFreq>20 OR "
                   "ctfCritfirstZeroRatio<0.9 OR ctfCritfirstZeroRatio>1.1 OR "
-                  "ctfCritCorr13==0 OR ctfCritFirstMinFirstZeroRatio>10 AND "
+                  "ctfCritFirstMinFirstZeroRatio>10 AND "
                   "ctfCritFirstMinFirstZeroRatio!=1000 OR "
-                  "ctfCritNonAstigmaticValidty<=0 OR " 
-                  "ctfCritNonAstigmaticValidty>25 OR ctfBgGaussian2SigmaU>70000 "
-                  "OR ctfCritIceness>1.01")
+                  "ctfCritNonAstigmaticValidty<0 OR ctfCritFitting>1 OR " 
+                  "ctfCritNonAstigmaticValidty>25 "
+                  "OR ctfCritIceness>1.01")  #OR ctfBgGaussian2SigmaU>70000 ctfCritCorr13==0 OR
 
     def __init__(self, **args):
 
@@ -137,7 +137,10 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
     def _calculateDownsampleList(self, samplingRate):
         
         if self.AutoDownsampling:
-            ctfDownFactor = self.calculateAutodownsampling(samplingRate)
+            if self.findPhaseShift:
+                ctfDownFactor = self.calculateAutodownsampling(samplingRate, 1.0)
+            else:
+                ctfDownFactor = self.calculateAutodownsampling(samplingRate)
         else:
             ctfDownFactor = self.ctfDownFactor.get()
         downsampleList = [ctfDownFactor]
@@ -160,7 +163,10 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
             if self.ctfDict[micName] > 0:
                 localParams['defocusU'], localParams['phaseShift0'] = \
                     self.ctfDict[micName]
-                localParams['defocus_range'] = 0.1 * localParams['defocusU']
+                if self.findPhaseShift:
+                    localParams['defocus_range'] = 0.15 * localParams['defocusU']
+                else:
+                    localParams['defocus_range'] = 0.1 * localParams['defocusU']
 
         else:
             ma = self._params['maxDefocus']

--- a/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_ctf_micrographs.py
@@ -163,10 +163,7 @@ class XmippProtCTFMicrographs(em.ProtCTFMicrographs):
             if self.ctfDict[micName] > 0:
                 localParams['defocusU'], localParams['phaseShift0'] = \
                     self.ctfDict[micName]
-                if self.findPhaseShift:
-                    localParams['defocus_range'] = 0.1 * localParams['defocusU']
-                else:
-                    localParams['defocus_range'] = 0.1 * localParams['defocusU']
+                localParams['defocus_range'] = 0.1 * localParams['defocusU']
 
         else:
             ma = self._params['maxDefocus']

--- a/software/em/xmipp/libraries/data/ctf.cpp
+++ b/software/em/xmipp/libraries/data/ctf.cpp
@@ -1118,6 +1118,10 @@ void CTFDescription1D::forcePhysicalMeaning()
         {
         	phase_shift = phase_shift/floor(phase_shift/3.14) - 3.14;
         }
+        if (phase_shift < 0)
+        {
+        	phase_shift = phase_shift + 3.14;
+        }
     }
 }
 #undef DEBUG
@@ -1805,7 +1809,7 @@ void CTFDescription::forcePhysicalMeaning()
             if (cV2*Tm < 0.01)
                 cV2 = 0.011 / Tm;
         }
-    }
+}
 }
 #undef DEBUG
 

--- a/software/em/xmipp/libraries/data/ctf.cpp
+++ b/software/em/xmipp/libraries/data/ctf.cpp
@@ -537,7 +537,10 @@ void CTFDescription1D::readParams(XmippProgram * program)
 	if (program->checkParam("--Q0"))
 		Q0=program->getDoubleParam("--Q0");
 	if (program->checkParam("--phase_shift"))
+	{
 		phase_shift=program->getDoubleParam("--phase_shift");
+		phase_shift=(phase_shift*PI)/180;
+	}
 	else
 		phase_shift = 0.0;
 	if (program->checkParam("--VPP_radius"))
@@ -600,7 +603,7 @@ std::ostream & operator << (std::ostream &out, const CTFDescription1D &ctf)
 
 
 /* Default values ---------------------------------------------------------- */
-void CTFDescription1D::clear()  // Esta parte es nueva
+void CTFDescription1D::clear()
 {
 	enable_CTF = true;
 	enable_CTFnoise = false;
@@ -897,7 +900,7 @@ bool CTFDescription1D::hasPhysicalMeaning()
             espr >= 0    && espr <= 20      &&
             ispr >= 0    && ispr <= 20      &&
             Cs >= 0      && Cs <= 20        &&
-            Ca >= 0      && Ca <= 3         &&
+            Ca >= 0      && Ca <= 7         &&
             alpha >= 0   && alpha <= 5      &&
             DeltaF >= 0  && DeltaF <= 1000  &&
             DeltaR >= 0  && DeltaR <= 100   &&
@@ -1117,14 +1120,14 @@ void CTFDescription1D::forcePhysicalMeaning()
             if (Gc2*Tm < 0.01)
                 Gc2 = 0.011 / Tm;
         }
-        if (phase_shift > 3.14) //Normalize phase shift between 0-PI
+        if (phase_shift > PI || phase_shift < -PI) //Normalize phase shift between 0-PI
         {
-        	phase_shift = phase_shift - floor(phase_shift/3.14)*3.14;
+        	phase_shift = realWRAP(phase_shift,-PI,PI);//phase_shift - floor(phase_shift/3.14)*3.14;
         }
-        if (phase_shift < 0)
+        /*if (phase_shift < 0)
         {
         	phase_shift = -(phase_shift - ceil(phase_shift/3.14)*3.14);//3.14 + phase_shift - ceil(phase_shift/3.14)*3.14;
-        }
+        }*/
     }
 }
 #undef DEBUG
@@ -1587,8 +1590,8 @@ bool CTFDescription::hasPhysicalMeaning()
             espr >= 0    && espr <= 20      &&
             ispr >= 0    && ispr <= 20      &&
             Cs >= 0      && Cs <= 20        &&
-            Ca >= 0      && Ca <= 3         &&
-            alpha >= 0   && alpha <= 5      &&
+            Ca >= 0      && Ca <= 7         &&
+            alpha >= 0   && alpha <= 9      &&
             DeltaF >= 0  && DeltaF <= 1000  &&
             DeltaR >= 0  && DeltaR <= 100   &&
             Q0 >= 0      && Q0 <= 0.40      &&
@@ -1604,7 +1607,7 @@ bool CTFDescription::hasPhysicalMeaning()
             << "espr>=0    && espr<=20      " << (espr >= 0    && espr <= 20)     << std::endl
             << "ispr>=0    && ispr<=20      " << (ispr >= 0    && ispr <= 20)     << std::endl
             << "Cs>=0      && Cs<=20        " << (Cs >= 0      && Cs <= 20)       << std::endl
-            << "Ca>=0      && Ca<=3         " << (Ca >= 0      && Ca <= 3)        << std::endl
+            << "Ca>=0      && Ca<=3         " << (Ca >= 0      && Ca <= 7)        << std::endl
             << "alpha>=0   && alpha<=5      " << (alpha >= 0   && alpha <= 5)     << std::endl
             << "DeltaF>=0  && DeltaF<=1000  " << (DeltaF >= 0  && DeltaF <= 1000) << std::endl
             << "DeltaR>=0  && DeltaR<=100   " << (DeltaR >= 0  && DeltaR <= 100)  << std::endl
@@ -1641,7 +1644,7 @@ bool CTFDescription::hasPhysicalMeaning()
             gaussian_angle >= 0  && gaussian_angle <= 90  &&
             sqrt_angle >= 0      && sqrt_angle <= 90      &&
             gaussian_angle2 >= 0 && gaussian_angle2 <= 90 &&
-			phase_shift >= 0.0   && phase_shift <= 3.14
+			phase_shift >= -PI   && phase_shift <= PI
             ;
         if (min_sigma > 0)
             retval2 = retval2 && ABS(sigmaU - sigmaV) / min_sigma <= 3;
@@ -1697,7 +1700,6 @@ bool CTFDescription::hasPhysicalMeaning()
 #ifdef DEBUG
 
 #endif
-
     return retval && retval2;
 }
 #undef DEBUG

--- a/software/em/xmipp/libraries/data/ctf.cpp
+++ b/software/em/xmipp/libraries/data/ctf.cpp
@@ -946,7 +946,9 @@ bool CTFDescription1D::hasPhysicalMeaning()
             gaussian_K2 >= 0     &&
             sigma2 >= 0          &&
             sigma2 <= 100e3      &&
-            Gc2 >= 0;
+            Gc2 >= 0             &&
+			phase_shift >= 0.0 && phase_shift <= 3.14
+			;
 
         if (min_sigma > 0)
             retval2 = retval2 && sigma1 / min_sigma <= 3;
@@ -960,6 +962,7 @@ bool CTFDescription1D::hasPhysicalMeaning()
             retval2 = retval2 && Gc2 / min_c2 <= 3;
         if (gaussian_K2 != 0)
             retval2 = retval2 && (Gc2 * Tm >= 0.01);
+
 #ifdef DEBUG
 
         if (retval2 == false)
@@ -1002,7 +1005,7 @@ bool CTFDescription1D::hasPhysicalMeaning()
 #ifdef DEBUG
 
 #endif
-
+    //std::cout << "retval " << retval << " " << "retval2 =" << retval2 << std::endl;
     return retval && retval2;
 }
 #undef DEBUG
@@ -1120,7 +1123,7 @@ void CTFDescription1D::forcePhysicalMeaning()
         }
         if (phase_shift < 0)
         {
-        	phase_shift = 3.14 + phase_shift - ceil(phase_shift/3.14)*3.14;
+        	phase_shift = -(phase_shift - ceil(phase_shift/3.14)*3.14);//3.14 + phase_shift - ceil(phase_shift/3.14)*3.14;
         }
     }
 }
@@ -1637,7 +1640,8 @@ bool CTFDescription::hasPhysicalMeaning()
             cU2 >= 0             && cV2 >= 0              &&
             gaussian_angle >= 0  && gaussian_angle <= 90  &&
             sqrt_angle >= 0      && sqrt_angle <= 90      &&
-            gaussian_angle2 >= 0 && gaussian_angle2 <= 90
+            gaussian_angle2 >= 0 && gaussian_angle2 <= 90 &&
+			phase_shift >= 0.0   && phase_shift <= 3.14
             ;
         if (min_sigma > 0)
             retval2 = retval2 && ABS(sigmaU - sigmaV) / min_sigma <= 3;

--- a/software/em/xmipp/libraries/data/ctf.cpp
+++ b/software/em/xmipp/libraries/data/ctf.cpp
@@ -1124,10 +1124,6 @@ void CTFDescription1D::forcePhysicalMeaning()
         {
         	phase_shift = realWRAP(phase_shift,-PI,PI);//phase_shift - floor(phase_shift/3.14)*3.14;
         }
-        /*if (phase_shift < 0)
-        {
-        	phase_shift = -(phase_shift - ceil(phase_shift/3.14)*3.14);//3.14 + phase_shift - ceil(phase_shift/3.14)*3.14;
-        }*/
     }
 }
 #undef DEBUG

--- a/software/em/xmipp/libraries/data/ctf.cpp
+++ b/software/em/xmipp/libraries/data/ctf.cpp
@@ -1114,13 +1114,13 @@ void CTFDescription1D::forcePhysicalMeaning()
             if (Gc2*Tm < 0.01)
                 Gc2 = 0.011 / Tm;
         }
-        if (phase_shift > 3.14) //6.28
+        if (phase_shift > 3.14) //Normalize phase shift between 0-PI
         {
-        	phase_shift = phase_shift/floor(phase_shift/3.14) - 3.14;
+        	phase_shift = phase_shift - floor(phase_shift/3.14)*3.14;
         }
         if (phase_shift < 0)
         {
-        	phase_shift = phase_shift + 3.14;
+        	phase_shift = 3.14 + phase_shift - ceil(phase_shift/3.14)*3.14;
         }
     }
 }

--- a/software/em/xmipp/libraries/data/ctf.h
+++ b/software/em/xmipp/libraries/data/ctf.h
@@ -462,6 +462,7 @@ public:
 		double E = Eespr * EdeltaF * EdeltaR * Ealpha + envR0+envR1*precomputed.u+envR2*precomputed.u2;
 		if (E < 0)
 			E	= 0;
+
 		if (show)
 		{
 			std::cout << "   Deltaf=" << precomputed.deltaf << std::endl;
@@ -476,6 +477,7 @@ public:
 			<< std::endl;
 			std::cout << "   Total atenuation(E)= " << E << std::endl;
 			std::cout << "   K,Q0,base_line=" << K << "," << Q0 << "," << base_line << std::endl;
+			std::cout << "   VPP=" << VPP << std::endl;
 			std::cout << "   CTF="
 			<< -K*(Ksin*sine_part - Kcos*cosine_part)*E << std::endl;
 		}

--- a/software/em/xmipp/libraries/data/ctf.h
+++ b/software/em/xmipp/libraries/data/ctf.h
@@ -446,7 +446,7 @@ public:
 		double VPP;
 		double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
 		double argument = VPP + K1 * precomputed.deltaf * precomputed.u2 + K2 *precomputed.u4;
@@ -490,7 +490,7 @@ public:
 		double VPP;
 		double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
 		double argument = VPP + K1 * precomputed.deltaf * precomputed.u2 + K2 *precomputed.u4;
@@ -552,7 +552,7 @@ public:
 		double VPP;
 		double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-precomputed.u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
 		double argument = VPP + K1 * precomputed.deltaf * precomputed.u2 + K2 * precomputed.u4;
@@ -567,6 +567,7 @@ public:
 			std::cout << "   K1,K2,sin=" << K1 << " " << K2 << " "
 			<< std::endl;
 			std::cout << "   Q0=" << Q0 << std::endl;
+			std::cout << " VPP =" << VPP << std::endl;
 			std::cout << "   CTF without damping="
 			<< -(Ksin*sine_part - Kcos*cosine_part) << std::endl;
 		}
@@ -583,7 +584,7 @@ public:
 		double VPP;
 		double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
 		double argument = VPP + K1 * deltaf * u2 + K2 * u4;
@@ -1063,7 +1064,7 @@ public:
         double VPP;
         double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
         double argument = VPP + K1 * deltaf * u2 + K2 * u4;
@@ -1109,7 +1110,7 @@ public:
         double VPP;
         double check_VPP = round(VPP_radius*1000);
 		if(check_VPP != 0)
-			VPP = phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
+			VPP = -phase_shift*(1-exp(-u2/(2*pow(VPP_radius,2.0))));
 		else
 			VPP = 0;
         double argument = VPP + K1 * deltaf * u2 + K2 * u4;

--- a/software/em/xmipp/libraries/reconstruction/ctf_correct_wiener2d.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_correct_wiener2d.cpp
@@ -99,7 +99,6 @@ void ProgCorrectWiener2D::generateWienerFilter(MultidimArray<double> &Mwien, CTF
 	ctf.enable_CTF = true;
 	ctf.enable_CTFnoise = false;
 	ctf.produceSideInfo();
-
 	MultidimArray<std::complex<double> > ctfComplex;
 	MultidimArray<double> ctfIm;
 
@@ -206,6 +205,7 @@ void ProgCorrectWiener2D::processImage(const FileName &fnImg, const FileName &fn
 
 	img.read(fnImg);
 	ctf.readFromMdRow(rowIn);
+	ctf.phase_shift = (ctf.phase_shift*PI)/180;
 	img().setXmippOrigin();
 	Ydim = YSIZE(img());
 	Xdim = XSIZE(img());

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd.cpp
@@ -724,6 +724,14 @@ double ProgCTFEstimateFromPSD::CTF_fitness_object(double *p)
         }
     }
 
+    if ((initial_ctfmodel.phase_shift != 0.0 || initial_ctfmodel.phase_shift != 1.57079) && action >= 5)
+        {
+        	if (fabs(initial_ctfmodel.phase_shift - current_ctfmodel.phase_shift) > 0.05)
+        	{
+        		return heavy_penalization;
+        	}
+        }
+
     // Now the 2D error
     double distsum = 0;
     int N = 0, Ncorr = 0;

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_base.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_base.cpp
@@ -44,6 +44,7 @@ void ProgCTFBasicParams::readBasicParams(XmippProgram *program)
     modelSimplification = program->getIntParam("--model_simplification");
     bootstrap = program->checkParam("--bootstrapFit");
     fastDefocusEstimate = program->checkParam("--fastDefocus");
+    selfEstimation = program->checkParam("--selfEstimation");
     if (fastDefocusEstimate)
     {
         lambdaPhase=program->getDoubleParam("--fastDefocus",0);
@@ -156,6 +157,8 @@ void ProgCTFBasicParams::defineBasicParams(XmippProgram * program)
         "                                : If fmax<0.35, f1 default=0.02");
     program->addParamsLine(
         "   [--enhance_max_freq <f2>]    : Bandpass cutoff. Normalized to 0.5.");
+    program->addParamsLine(
+        "   [--selfEstimation]           : Estimate defocus without previous estimation");
     program->addParamsLine(
         "                                : If fmax>0.35, f2 default=0.08");
     program->addParamsLine(
@@ -282,8 +285,12 @@ void ProgCTFBasicParams::produceSideInfo()
 		if (w_digfreq(i,j)>min_freq && w_digfreq(i,j)<max_freq)
 		{
 			int r = w_digfreq_r(i, j);
+			//int r2 = w_digfreq_r(i,j)*w_digfreq_r(i,j);
+			//std::cout << "r =" << r << std::endl;
+			//std::cout << "r2 =" << r2 << std::endl;
 			w_digfreq_r_iN(r)+=1;
 			psd_exp_enhanced_radial(r) += enhanced_ctftomodel(i, j);
+			//psd_exp_enhanced_radial_2(r2) += enhanced_ctftomodel(i, j);
 			psd_exp_radial(r) += ctftomodel(i, j);
 		}
 	}

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_base.h
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_base.h
@@ -24,6 +24,7 @@ public:
 	Image<double>        enhanced_ctftomodel_fullsize;
 	/// Show convergence values
 	bool                 show_optimization;
+	bool                 selfEstimation;
 	/// X dimension of particle projections (-1=the same as the psd)
 	int                  ctfmodelSize;
 	/// Bootstrap estimation
@@ -62,12 +63,15 @@ public:
 	///PSD data
 	MultidimArray<double> psd_exp_radial;
 	MultidimArray<double> psd_exp_enhanced_radial;
+	MultidimArray<double> psd_exp_enhanced_radial_2;
 	MultidimArray<double> psd_exp_enhanced_radial_derivative;
 	MultidimArray<double> psd_theo_radial_derivative;
 	MultidimArray<double> psd_exp_radial_derivative;
 	MultidimArray<double> psd_theo_radial;
 	MultidimArray<double> w_digfreq_r_iN;
 	MultidimArray<double> w_digfreq_r;
+	MultidimArray<std::complex<double> > psd_fft;
+	std::vector<double> amplitud;
 	///Masks
 	MultidimArray<double> mask;
 	MultidimArray<double> mask_between_zeroes;

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1361,7 +1361,6 @@ double ROUT_Adjust_CTFFast(ProgCTFEstimateFromPSDFast &prm, CTFDescription1D &ou
 	steps.initConstant(1);
 	steps(1) = 0; // kV
 	steps(3) = 0; // The spherical aberration (Cs) is not optimized
-	//steps(4) = 0;
 	steps(27) = 0; //VPP radius not optimized
 	if (prm.initial_ctfmodel.Q0 != 0)
 		steps(13) = 0; // Q0

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1082,8 +1082,6 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 	}
 	else
 	{
-		/*if (show_optimization)
-				std::cout << "Looking for first defoci ...\n";
 		double best_defocus, best_K=1;
 		double best_error = heavy_penalization * 1.1;
 		bool first = true;
@@ -1168,12 +1166,7 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 						errmax = error(ii);
 				}
 			}
-			if (show_optimization)
-				std::cout << "Error matrix\n" << error << std::endl;
-
 			// Find those defoci which are within a 10% of the maximum
-			if (show_inf >= 2)
-				std::cout << "Range=" << errmax - errmin << std::endl;
 			double best_defocusmin = best_defocus, best_defocusmax = best_defocus;
 			for (defocus = defocus0, i = 0; defocus <= defocusF; defocus +=
 					 defocusStep, i++)
@@ -1193,19 +1186,11 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 								 best_defocusmin - defocusStep);
 
 			i = 0;
-			if (show_inf >= 2)
-			{
-				Image<double> save;
-				save() = error;
-				save.write("error.xmp");
-				std::cout << "Press any key: Error saved\n";
-				char c;
-				std::cin >> c;
-			}
 		}
 
 		current_ctfmodel.Defocus = best_defocus;
 		current_ctfmodel.K = best_K;
+	}
 
 		// Keep the result in adjust
 		current_ctfmodel.forcePhysicalMeaning();
@@ -1216,55 +1201,8 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 		{
 			std::cout << "First defocus Fit:\n" << ctfmodel_defoci << std::endl;
 			saveIntermediateResults_fast("step03a_first_defocus_fit_fast", true);
-		}*/
-
-		MultidimArray<double> psd_exp_enhanced_radial2;
-		/*MultidimArray<double> background;
-		generateModelSoFar_fast(background, false);
-		FOR_ALL_ELEMENTS_IN_ARRAY1D(background)
-		{
-			A1D_ELEM(background,i)= background(i)-psd_exp_enhanced_radial(i);
-		}*/
-		psd_exp_enhanced_radial2.initZeros(psd_exp_enhanced_radial);
-		double deltaW=1.0/XSIZE(w_digfreq);
-		double wmax=(XSIZE(w_digfreq)/2.0-1)/XSIZE(w_digfreq);
-		std::cout << "deltaW" << deltaW << std::endl;
-		double deltaW2=(wmax*wmax)/(XSIZE(w_digfreq)/2.0-1);
-		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_exp_enhanced_radial2)
-		{
-			double w2=i*deltaW2;
-			double w=sqrt(w2);
-			double widx=w/deltaW;
-			size_t lowerIdx=floor(widx);
-			double weight=widx-floor(widx);
-			A1D_ELEM(psd_exp_enhanced_radial2,i)=(1-weight)*A1D_ELEM(psd_exp_enhanced_radial,lowerIdx)
-					                             +weight*A1D_ELEM(psd_exp_enhanced_radial,lowerIdx+1);
 		}
-		std::cout<< "psd_exp_enhanced_radial  " <<psd_exp_enhanced_radial  << std::endl;
-		std::cout<< "psd_exp_enhanced_radial2 " <<psd_exp_enhanced_radial2 << std::endl;
-		//exit(1);
-		FourierTransformer FourierPSD;
-		FourierPSD.FourierTransform(psd_exp_enhanced_radial2, psd_fft, false);
 
-		for (size_t i = 0; i <= XSIZE(psd_fft); i++)
-		{
-			amplitud.push_back(sqrt(std::real(psd_fft[i])*std::real(psd_fft[i])+std::imag(psd_fft[i])*std::imag(psd_fft[i])));
-		}
-		current_ctfmodel.Defocus = (*max_element(amplitud.rbegin(),amplitud.rend()))*100000;
-
-	}
-
-	// Keep the result in adjust
-	std::cout << current_ctfmodel.Defocus << std::endl;
-	current_ctfmodel.forcePhysicalMeaning();
-	COPY_ctfmodel_TO_CURRENT_GUESS;
-	ctfmodel_defoci = current_ctfmodel;
-
-	if  (show_optimization)
-	{
-		std::cout << "First defocus Fit:\n" << ctfmodel_defoci << std::endl;
-		saveIntermediateResults_fast("step03a_first_defocus_fit_fast", true);
-	}
 
 }
 

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1015,7 +1015,6 @@ void ProgCTFEstimateFromPSDFast::estimate_envelope_parameters_fast()
     steps.initConstant(1);
 
     steps(1) = 0; // Do not optimize Cs
-    //steps(2) = 0;
     steps(5) = 0; // Do not optimize for alpha, since Ealpha depends on the defocus
 
     if (modelSimplification >= 1)
@@ -1082,7 +1081,7 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 	}
 	else
 	{
-		/*double best_defocus, best_K=1;
+		double best_defocus, best_K=1;
 		double best_error = heavy_penalization * 1.1;
 		bool first = true;
 		int i;
@@ -1189,65 +1188,8 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 		}
 
 		current_ctfmodel.Defocus = best_defocus;
-		current_ctfmodel.K = best_K;*/
-		MultidimArray<double> psd_exp_radial2;
-		/*MultidimArray<double> background;
-		generateModelSoFar_fast(background, false);
-		FOR_ALL_ELEMENTS_IN_ARRAY1D(background)
-		{
-			A1D_ELEM(background,i)= background(i)-psd_exp_radial(i);
-		}*/
-		psd_exp_radial2.initZeros(psd_exp_radial);
-		double deltaW=1.0/XSIZE(w_digfreq);
-		double wmax=(XSIZE(w_digfreq)/2.0-1)/XSIZE(w_digfreq);
-		double deltaW2=(wmax*wmax)/(XSIZE(w_digfreq)/2.0-1);
-		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_exp_radial2)
-		{
-			double w2=i*deltaW2;
-			double w=sqrt(w2);
-			double widx=w/deltaW;
-			size_t lowerIdx=floor(widx);
-			double weight=widx-floor(widx);
-			A1D_ELEM(psd_exp_radial2,i)=(1-weight)*A1D_ELEM(psd_exp_radial,lowerIdx)
-												 +weight*A1D_ELEM(psd_exp_radial,lowerIdx+1);
-		}
-		//std::cout << "radial2 =" << psd_exp_radial2 << std::endl;
-		//exit(1);
-		FourierTransformer FourierPSD;
-		FourierPSD.FourierTransform(psd_exp_radial2, psd_fft, false);
-		int index = 0;
-		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_fft)
-		{
-			amplitud.push_back(sqrt(std::real(psd_fft[i])*std::real(psd_fft[i])+std::imag(psd_fft[i])*std::imag(psd_fft[i])));
-		}
-		for(size_t i=0;i<amplitud.size();i++)
-		{
-			double change = amplitud[i+1]-amplitud[i];
-			if(change > 0.0)
-			{
-				double initialIndex = index;
-				break;
-			}
-			index++;
-		}
+		current_ctfmodel.K = best_K;
 
-		amplitud.erase(amplitud.begin(),amplitud.begin()+index);
-		double maxValue = *max_element(amplitud.rbegin(),amplitud.rend());
-		int finalIndex = 0;
-		for(size_t i=0;i<amplitud.size();i++)
-		{
-			if(maxValue == amplitud[i])
-			{
-				current_ctfmodel.Defocus = (((current_ctfmodel.Tm*current_ctfmodel.Tm)*
-						(XSIZE(w_digfreq)/2-finalIndex+index))/
-						(XSIZE(w_digfreq)*2*PI*current_ctfmodel.lambda))*1000;
-				break;
-			}
-			finalIndex++;
-		}
-		std::cout << finalIndex << " " << index << std::endl;
-		std::cout << finalIndex+index+XSIZE(w_digfreq)/2 << std::endl;
-		std::cout << current_ctfmodel.Defocus << std::endl;
 	}
 		// Keep the result in adjust
 		current_ctfmodel.forcePhysicalMeaning();

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1082,7 +1082,7 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 	}
 	else
 	{
-		double best_defocus, best_K=1;
+		/*double best_defocus, best_K=1;
 		double best_error = heavy_penalization * 1.1;
 		bool first = true;
 		int i;
@@ -1189,9 +1189,66 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 		}
 
 		current_ctfmodel.Defocus = best_defocus;
-		current_ctfmodel.K = best_K;
-	}
+		current_ctfmodel.K = best_K;*/
+		MultidimArray<double> psd_exp_radial2;
+		/*MultidimArray<double> background;
+		generateModelSoFar_fast(background, false);
+		FOR_ALL_ELEMENTS_IN_ARRAY1D(background)
+		{
+			A1D_ELEM(background,i)= background(i)-psd_exp_radial(i);
+		}*/
+		psd_exp_radial2.initZeros(psd_exp_radial);
+		double deltaW=1.0/XSIZE(w_digfreq);
+		double wmax=(XSIZE(w_digfreq)/2.0-1)/XSIZE(w_digfreq);
+		double deltaW2=(wmax*wmax)/(XSIZE(w_digfreq)/2.0-1);
+		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_exp_radial2)
+		{
+			double w2=i*deltaW2;
+			double w=sqrt(w2);
+			double widx=w/deltaW;
+			size_t lowerIdx=floor(widx);
+			double weight=widx-floor(widx);
+			A1D_ELEM(psd_exp_radial2,i)=(1-weight)*A1D_ELEM(psd_exp_radial,lowerIdx)
+												 +weight*A1D_ELEM(psd_exp_radial,lowerIdx+1);
+		}
+		//std::cout << "radial2 =" << psd_exp_radial2 << std::endl;
+		//exit(1);
+		FourierTransformer FourierPSD;
+		FourierPSD.FourierTransform(psd_exp_radial2, psd_fft, false);
+		int index = 0;
+		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_fft)
+		{
+			amplitud.push_back(sqrt(std::real(psd_fft[i])*std::real(psd_fft[i])+std::imag(psd_fft[i])*std::imag(psd_fft[i])));
+		}
+		for(size_t i=0;i<amplitud.size();i++)
+		{
+			double change = amplitud[i+1]-amplitud[i];
+			if(change > 0.0)
+			{
+				double initialIndex = index;
+				break;
+			}
+			index++;
+		}
 
+		amplitud.erase(amplitud.begin(),amplitud.begin()+index);
+		double maxValue = *max_element(amplitud.rbegin(),amplitud.rend());
+		int finalIndex = 0;
+		for(size_t i=0;i<amplitud.size();i++)
+		{
+			if(maxValue == amplitud[i])
+			{
+				current_ctfmodel.Defocus = (((current_ctfmodel.Tm*current_ctfmodel.Tm)*
+						(XSIZE(w_digfreq)/2-finalIndex+index))/
+						(XSIZE(w_digfreq)*2*PI*current_ctfmodel.lambda))*1000;
+				break;
+			}
+			finalIndex++;
+		}
+		std::cout << finalIndex << " " << index << std::endl;
+		std::cout << finalIndex+index+XSIZE(w_digfreq)/2 << std::endl;
+		std::cout << current_ctfmodel.Defocus << std::endl;
+	}
 		// Keep the result in adjust
 		current_ctfmodel.forcePhysicalMeaning();
 		COPY_ctfmodel_TO_CURRENT_GUESS;

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1444,6 +1444,7 @@ double ROUT_Adjust_CTFFast(ProgCTFEstimateFromPSDFast &prm, CTFDescription1D &ou
 		prm2D->saveIntermediateResults("step05b_estimate_2D_parameters", true);
 	}
 
+	//prm2D->saveIntermediateResults("/home/javiermota/Documents/MATLAB/VPP/step05b_estimate_2D_parameters", true);
 	/************************************************************************/
 	/* STEP 13: Produce output                                              */
 	/************************************************************************/
@@ -1467,11 +1468,13 @@ double ROUT_Adjust_CTFFast(ProgCTFEstimateFromPSDFast &prm, CTFDescription1D &ou
 
 		}
 #endif
+		//prm2D->saveIntermediateResults("/home/javiermota/Documents/MATLAB/VPP/step06_estimate_2D_parameters", true);
         XX(u)=1; YY(u)=0;
         prm2D->current_ctfmodel.lookFor(3, u, z3, 0);
         prm2D->current_ctfmodel.lookFor(1, u, z1, 0);
         double z1m = z1.module();
         double z3m = z3.module();
+
 		FOR_ALL_DIRECT_ELEMENTS_IN_MULTIDIMARRAY(prm2D->mask_between_zeroes)
 		{
 			double wn=DIRECT_MULTIDIM_ELEM(prm2D->w_contfreq, n);
@@ -1482,7 +1485,6 @@ double ROUT_Adjust_CTFFast(ProgCTFEstimateFromPSDFast &prm, CTFDescription1D &ou
 		CTF_fitness(prm2D->adjust_params->adaptForNumericalRecipes(), prm2D);
 		// Save results
 		FileName fn_rootCTFPARAM = prm2D->fn_psd.withoutExtension();
-
 		FileName fn_rootMODEL = fn_rootCTFPARAM;
 		size_t atPosition=fn_rootCTFPARAM.find('@');
 

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1219,6 +1219,12 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 		}*/
 
 		MultidimArray<double> psd_exp_enhanced_radial2;
+		/*MultidimArray<double> background;
+		generateModelSoFar_fast(background, false);
+		FOR_ALL_ELEMENTS_IN_ARRAY1D(background)
+		{
+			A1D_ELEM(background,i)= background(i)-psd_exp_enhanced_radial(i);
+		}*/
 		psd_exp_enhanced_radial2.initZeros(psd_exp_enhanced_radial);
 		double deltaW=1.0/XSIZE(w_digfreq);
 		double wmax=(XSIZE(w_digfreq)/2.0-1)/XSIZE(w_digfreq);
@@ -1236,7 +1242,7 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 		}
 		std::cout<< "psd_exp_enhanced_radial  " <<psd_exp_enhanced_radial  << std::endl;
 		std::cout<< "psd_exp_enhanced_radial2 " <<psd_exp_enhanced_radial2 << std::endl;
-		exit(1);
+		//exit(1);
 		FourierTransformer FourierPSD;
 		FourierPSD.FourierTransform(psd_exp_enhanced_radial2, psd_fft, false);
 
@@ -1245,11 +1251,7 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 			amplitud.push_back(sqrt(std::real(psd_fft[i])*std::real(psd_fft[i])+std::imag(psd_fft[i])*std::imag(psd_fft[i])));
 		}
 		current_ctfmodel.Defocus = (*max_element(amplitud.rbegin(),amplitud.rend()))*100000;
-		/*(*adjust_params)(0) = initial_ctfmodel.Defocus;
-		(*adjust_params)(2) = current_ctfmodel.K;
-		powellOptimizer(*adjust_params, FIRST_DEFOCUS_PARAMETER + 1,
-								DEFOCUS_PARAMETERS, CTF_fitness_fast, global_prm, 0.05,
-								fitness, iter, steps, false);*/
+
 	}
 
 	// Keep the result in adjust

--- a/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_estimate_from_psd_fast.cpp
@@ -1217,12 +1217,32 @@ void ProgCTFEstimateFromPSDFast::estimate_defoci_fast()
 			std::cout << "First defocus Fit:\n" << ctfmodel_defoci << std::endl;
 			saveIntermediateResults_fast("step03a_first_defocus_fit_fast", true);
 		}*/
+
+		MultidimArray<double> psd_exp_enhanced_radial2;
+		psd_exp_enhanced_radial2.initZeros(psd_exp_enhanced_radial);
+		double deltaW=1.0/XSIZE(w_digfreq);
+		double wmax=(XSIZE(w_digfreq)/2.0-1)/XSIZE(w_digfreq);
+		std::cout << "deltaW" << deltaW << std::endl;
+		double deltaW2=(wmax*wmax)/(XSIZE(w_digfreq)/2.0-1);
+		FOR_ALL_ELEMENTS_IN_ARRAY1D(psd_exp_enhanced_radial2)
+		{
+			double w2=i*deltaW2;
+			double w=sqrt(w2);
+			double widx=w/deltaW;
+			size_t lowerIdx=floor(widx);
+			double weight=widx-floor(widx);
+			A1D_ELEM(psd_exp_enhanced_radial2,i)=(1-weight)*A1D_ELEM(psd_exp_enhanced_radial,lowerIdx)
+					                             +weight*A1D_ELEM(psd_exp_enhanced_radial,lowerIdx+1);
+		}
+		std::cout<< "psd_exp_enhanced_radial  " <<psd_exp_enhanced_radial  << std::endl;
+		std::cout<< "psd_exp_enhanced_radial2 " <<psd_exp_enhanced_radial2 << std::endl;
+		exit(1);
 		FourierTransformer FourierPSD;
-		FourierPSD.FourierTransform(psd_exp_enhanced_radial, psd_fft, false);
-		for(int i = 0; i <= psd_fft.xdim; i++)
+		FourierPSD.FourierTransform(psd_exp_enhanced_radial2, psd_fft, false);
+
+		for (size_t i = 0; i <= XSIZE(psd_fft); i++)
 		{
 			amplitud.push_back(sqrt(std::real(psd_fft[i])*std::real(psd_fft[i])+std::imag(psd_fft[i])*std::imag(psd_fft[i])));
-
 		}
 		current_ctfmodel.Defocus = (*max_element(amplitud.rbegin(),amplitud.rend()))*100000;
 		/*(*adjust_params)(0) = initial_ctfmodel.Defocus;

--- a/software/em/xmipp/libraries/reconstruction/ctf_phase_flip.cpp
+++ b/software/em/xmipp/libraries/reconstruction/ctf_phase_flip.cpp
@@ -96,6 +96,8 @@ void actualPhaseFlip(MultidimArray<double> &I, CTFDescription ctf)
     int yDim=YSIZE(I);
     int xDim=XSIZE(I);
     double iTm=1.0/ctf.Tm;
+    ctf.phase_shift = (ctf.phase_shift*PI)/180;
+
     for (size_t i=0; i<YSIZE(M_inFourier); ++i)
     {
     	FFT_IDX2DIGFREQ(i, yDim, YY(freq));


### PR DESCRIPTION
Problems with phase shift label fixed. Propagation of the phase shift label to phase flip and Wiener filter.
Now xmipp ctf estimation is able to estimate the defocus by itself.
CtfEstimateFromPsdFast test done.