### PR TITLE
Release 1.2.1 dm4

### DIFF
--- a/config/templates/scipion.template
+++ b/config/templates/scipion.template
@@ -107,6 +107,8 @@ JAVA_BINDIR = %(JAVA_HOME)s/bin
 JAVAC = %(JAVA_BINDIR)s/javac
 JAR = %(JAVA_BINDIR)s/jar
 JNI_CPPPATH = %(JAVA_HOME)s/include:%(JAVA_HOME)s/include/linux
+# Will be used as Xmx JVM param. In GB. Might be increased in specific cases: viewing movies +1
+JAVA_MAX_MEMORY = 2
 
 # Modules to compile
 GTEST = False

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -153,10 +153,13 @@ class XmippViewer(Viewer):
             fn = obj.getFileName()
             # Enabled for the future has to be available
             labels = 'id _filename _samplingRate  '
-            self._views.append(ObjectView(self._project, obj.strId(), fn,
-                                          viewParams={ORDER: labels,
-                                                      VISIBLE: labels,
-                                                      MODE: MODE_MD, RENDER: "no"}))
+            moviesView = ObjectView(self._project, obj.strId(), fn,
+                                      viewParams={ORDER: labels,
+                                                  VISIBLE: labels,
+                                                  MODE: MODE_MD, RENDER: "no"})
+            # For movies increase the JVM memory by 1 GB, just in case
+            moviesView.setMemory(showj.getJVMMaxMemory() + 1)
+            self._views.append(moviesView)
 
         elif issubclass(cls, SetOfMicrographs):
             self._views.append(MicrographsView(self._project, obj, **kwargs))

--- a/pyworkflow/em/showj.py
+++ b/pyworkflow/em/showj.py
@@ -103,6 +103,11 @@ PROJECT_PATH = 'projectPath'
 OBJECT_ID = 'objectId'
 
 
+def getJVMMaxMemory():
+    # Memory in GB
+    return os.environ.get("JAVA_MAX_MEMORY", 2)
+
+
 class ColumnsConfig():
     """ Store the configuration of the columns for a given table in a dataset.
     The order of the columns will be stored and configuration for each columns.
@@ -241,8 +246,8 @@ def getJavaIJappArguments(memory, appName, appArgs):
     appName: the qualified name of the java application.
     appArgs: the arguments specific to the application.
     """ 
-    if len(memory) == 0:
-        memory = "1g"
+    if memory is None:
+        memory = getJVMMaxMemory()
         print "No memory size provided. Using default: " + memory
     
     jdkLib = join(os.environ['JAVA_HOME'], 'lib')
@@ -251,7 +256,7 @@ def getJavaIJappArguments(memory, appName, appArgs):
     javaLib = join(os.environ['XMIPP_HOME'], 'java', 'lib')
     plugins_dir = os.path.join(imagej_home, "plugins")
     arch = getArchitecture()
-    args = "-Xmx%(memory)s -d%(arch)s -Djava.library.path=%(lib)s -Dplugins.dir=%(plugins_dir)s -cp %(jdkLib)s/*:%(imagej_home)s/*:%(javaLib)s/* %(appName)s %(appArgs)s" % locals()
+    args = "-Xmx%(memory)sg -d%(arch)s -Djava.library.path=%(lib)s -Dplugins.dir=%(plugins_dir)s -cp %(jdkLib)s/*:%(imagej_home)s/*:%(javaLib)s/* %(appName)s %(appArgs)s" % locals()
 
     return args
 
@@ -265,7 +270,8 @@ def runJavaIJapp(memory, appName, args, env={}):
     cmd = ['java'] + shlex.split(args)
     return subprocess.Popen(cmd, env=env)
 
-def launchSupervisedPickerGUI(micsFn, outputDir, protocol, mode=None, memory='2g', pickerProps=None, inTmpFolder = False):
+def launchSupervisedPickerGUI(micsFn, outputDir, protocol, mode=None, memory=None, pickerProps=None, inTmpFolder = False):
+
         app = "xmipp.viewer.particlepicker.training.SupervisedPickerRunner"
         args = "--input %s --output %s"%(micsFn, outputDir)
         if mode:
@@ -279,7 +285,7 @@ def launchSupervisedPickerGUI(micsFn, outputDir, protocol, mode=None, memory='2g
         if inTmpFolder:
             args += " --tmp true"
 
-        return runJavaIJapp("%s" % memory, app, args)
+        return runJavaIJapp(memory, app, args)
     
 
 def launchTiltPairPickerGUI(micsFn, outputDir, protocol, mode=None, memory='2g'):

--- a/pyworkflow/em/viewer.py
+++ b/pyworkflow/em/viewer.py
@@ -64,10 +64,13 @@ class DataView(View):
     """ Wrapper the arguments to showj (either web or desktop). """
     def __init__(self, path, viewParams={}, **kwargs):
         View.__init__(self)
-        self._memory = '2g'
+        self._memory = showj.getJVMMaxMemory()
         self._loadPath(path)
         self._env = kwargs.get('env', {})
         self._viewParams = viewParams
+
+    def setMemory(self, memory):
+        self._memory = memory
 
     def getViewParams(self):
         """ Give access to the viewParams dict. """

--- a/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
@@ -48,7 +48,8 @@ public class ImagePlusFromFile extends ImagePlusReader{
 			if (ig == null || hasChanged())
             {
                 if(Filename.isXmippSupported(fileName))
-                    System.out.println ("ImagePlus loadImagePlus: isXmippSupported";
+                {
+                    System.out.println ("ImagePlus loadImagePlus: isXmippSupported");
                     try
                     {
                         ig = new ImageGeneric(fileName);//to read again file
@@ -56,13 +57,14 @@ public class ImagePlusFromFile extends ImagePlusReader{
                     catch(Exception e)
                     {
                         imp = new ImagePlus(fileName);
-                        System.out.println ("ImagePlus loadImagePlus: Failed ImageGeneric, Using ImagePlus instead";
+                        System.out.println ("ImagePlus loadImagePlus: Failed ImageGeneric, Using ImagePlus instead");
                     }
+                }
                 else
                     imp = new ImagePlus(fileName);
                 if(ig != null && !hasIndex())
                 {
-                    System.out.println ("ImagePlus loadImagePlus: inside if(ig != null && !hasIndex())";
+                    System.out.println ("ImagePlus loadImagePlus: inside if(ig != null && !hasIndex())");
                     imp = XmippImageConverter.readToImagePlus(ig);
                 }
                 else if(ig != null)

--- a/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
@@ -48,6 +48,7 @@ public class ImagePlusFromFile extends ImagePlusReader{
 			if (ig == null || hasChanged())
             {
                 if(Filename.isXmippSupported(fileName))
+                    System.out.println ("ImagePlus loadImagePlus: isXmippSupported";
                     try
                     {
                         ig = new ImageGeneric(fileName);//to read again file
@@ -55,11 +56,13 @@ public class ImagePlusFromFile extends ImagePlusReader{
                     catch(Exception e)
                     {
                         imp = new ImagePlus(fileName);
+                        System.out.println ("ImagePlus loadImagePlus: Failed ImageGeneric, Using ImagePlus instead";
                     }
                 else
                     imp = new ImagePlus(fileName);
                 if(ig != null && !hasIndex())
                 {
+                    System.out.println ("ImagePlus loadImagePlus: inside if(ig != null && !hasIndex())";
                     imp = XmippImageConverter.readToImagePlus(ig);
                 }
                 else if(ig != null)

--- a/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/ImagePlusFromFile.java
@@ -48,8 +48,6 @@ public class ImagePlusFromFile extends ImagePlusReader{
 			if (ig == null || hasChanged())
             {
                 if(Filename.isXmippSupported(fileName))
-                {
-                    System.out.println ("ImagePlus loadImagePlus: isXmippSupported");
                     try
                     {
                         ig = new ImageGeneric(fileName);//to read again file
@@ -57,14 +55,11 @@ public class ImagePlusFromFile extends ImagePlusReader{
                     catch(Exception e)
                     {
                         imp = new ImagePlus(fileName);
-                        System.out.println ("ImagePlus loadImagePlus: Failed ImageGeneric, Using ImagePlus instead");
                     }
-                }
                 else
                     imp = new ImagePlus(fileName);
                 if(ig != null && !hasIndex())
                 {
-                    System.out.println ("ImagePlus loadImagePlus: inside if(ig != null && !hasIndex())");
                     imp = XmippImageConverter.readToImagePlus(ig);
                 }
                 else if(ig != null)

--- a/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
@@ -86,6 +86,8 @@ public class XmippImageConverter {
 
 	public static ImagePlus readToImagePlus(ImageGeneric image, int nslice)
 			throws Exception {
+		System.out.println ("image.getXDim() at readImagePlus: " + image.getXDim());
+		System.out.println ("image.getYDim() at readImagePlus: " + image.getYDim());
 		return readToImagePlus(image, image.getXDim(), image.getYDim(), nslice);
 	}
         

--- a/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
@@ -86,8 +86,6 @@ public class XmippImageConverter {
 
 	public static ImagePlus readToImagePlus(ImageGeneric image, int nslice)
 			throws Exception {
-		System.out.println ("image.getXDim() at readImagePlus: " + image.getXDim());
-		System.out.println ("image.getYDim() at readImagePlus: " + image.getYDim());
 		return readToImagePlus(image, image.getXDim(), image.getYDim(), nslice);
 	}
         
@@ -364,30 +362,22 @@ public class XmippImageConverter {
 	static ProcessorCreator createProcessorCreator(ImageGeneric image)
 			throws Exception {
 		ProcessorCreator pc = null;
-                        System.out.println("image.getDataType:"
-                         + image.getDataType()
-                         + ":  "
-                         + ImageGeneric.UHalfByte);
 		switch (image.getDataType()) {
 		case ImageGeneric.Float:
 		case ImageGeneric.Double:
 			pc = new ProcessorCreatorFloat();
-                        System.out.println("createProcessorCreator:1");
 			break;
 		case ImageGeneric.Short:
 		case ImageGeneric.UShort:
 			pc = new ProcessorCreatorShort();
-                        System.out.println("createProcessorCreator:2");
 			break;
 		case ImageGeneric.UHalfByte:
 		case ImageGeneric.SChar:
 		case ImageGeneric.UChar:
 			pc = new ProcessorCreatorByte();
-                        System.out.println("createProcessorCreator:3");
 			break;
 		default:
 			pc = new ProcessorCreatorFloat();
-                        System.out.println("createProcessorCreator:default");
 		}
 
 		return pc;

--- a/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
+++ b/software/em/xmipp/java/src/xmipp/ij/commons/XmippImageConverter.java
@@ -364,21 +364,30 @@ public class XmippImageConverter {
 	static ProcessorCreator createProcessorCreator(ImageGeneric image)
 			throws Exception {
 		ProcessorCreator pc = null;
+                        System.out.println("image.getDataType:"
+                         + image.getDataType()
+                         + ":  "
+                         + ImageGeneric.UHalfByte);
 		switch (image.getDataType()) {
 		case ImageGeneric.Float:
 		case ImageGeneric.Double:
 			pc = new ProcessorCreatorFloat();
+                        System.out.println("createProcessorCreator:1");
 			break;
 		case ImageGeneric.Short:
 		case ImageGeneric.UShort:
 			pc = new ProcessorCreatorShort();
+                        System.out.println("createProcessorCreator:2");
 			break;
+		case ImageGeneric.UHalfByte:
 		case ImageGeneric.SChar:
 		case ImageGeneric.UChar:
 			pc = new ProcessorCreatorByte();
+                        System.out.println("createProcessorCreator:3");
 			break;
 		default:
 			pc = new ProcessorCreatorFloat();
+                        System.out.println("createProcessorCreator:default");
 		}
 
 		return pc;

--- a/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
+++ b/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
@@ -28,7 +28,8 @@ public class ImageGeneric {
     public final static int ComplexFloat = 13;      // Complex floating point (8-byte)
     public final static int ComplexDouble = 14;     // Complex floating point (16-byte)
     public final static int Bool = 15;              // Boolean (1-byte?)
-    public final static int LastEntry = 16;         // This must be the last entry
+    public final static int UHalfByte = 16 ;         // 4 bits per pixel
+    public final static int LastEntry = 17;         // This must be the last entry
     
     //AxisView constants for volume reslice
     public final static int Z_NEG = 0;
@@ -143,7 +144,7 @@ public class ImageGeneric {
     }
 
     public void read(int width, int height, int slice, long image) throws Exception {
-        System.out.println("ImageGeneric.java_read width: " +
+        System.out.println("ImageGeneric.java_read width: " + width);
         read(filename, width, height, slice, image, true);
         // At this moment we don't know why
 //        read(Filename.getFilename(filename), width, height, slice, image, true);

--- a/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
+++ b/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
@@ -143,6 +143,7 @@ public class ImageGeneric {
     }
 
     public void read(int width, int height, int slice, long image) throws Exception {
+        System.out.println("ImageGeneric.java_read width: " +
         read(filename, width, height, slice, image, true);
         // At this moment we don't know why
 //        read(Filename.getFilename(filename), width, height, slice, image, true);

--- a/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
+++ b/software/em/xmipp/java/src/xmipp/jni/ImageGeneric.java
@@ -144,7 +144,6 @@ public class ImageGeneric {
     }
 
     public void read(int width, int height, int slice, long image) throws Exception {
-        System.out.println("ImageGeneric.java_read width: " + width);
         read(filename, width, height, slice, image, true);
         // At this moment we don't know why
 //        read(Filename.getFilename(filename), width, height, slice, image, true);

--- a/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
@@ -185,10 +185,10 @@ Java_xmipp_jni_ImageGeneric_getArrayByte(JNIEnv *env, jobject jobj, jlong select
 
         DataType dataType = image->getDatatype();
 
-        switch (dataType)
+    switch (dataType)
     {
-    case DT_UChar:
-        {
+        case DT_UChar:
+            {
             unsigned char *mdarray;
 
             // Get slice array.

--- a/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
@@ -183,6 +183,14 @@ Java_xmipp_jni_ImageGeneric_getArrayByte(JNIEnv *env, jobject jobj, jlong select
         size_t size = image->getSize();
         jbyteArray array = env->NewByteArray(size);
 
+        // This is a common place where JVM could run out of memory
+        // We are trying to warn the user about this problem right before a core dump happens
+        if(array == NULL){
+            std::cerr << "\n***********************************" << std::endl;
+            std::cerr << "JVM might have run out of memory. You may want to increase JVM memory" << std::endl;
+            std::cerr << "***********************************\n" << std::endl;
+        }
+
         DataType dataType = image->getDatatype();
 
     switch (dataType)

--- a/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.cpp
@@ -187,6 +187,7 @@ Java_xmipp_jni_ImageGeneric_getArrayByte(JNIEnv *env, jobject jobj, jlong select
 
     switch (dataType)
     {
+        case DT_UHalfByte:
         case DT_UChar:
             {
             unsigned char *mdarray;
@@ -378,6 +379,7 @@ Java_xmipp_jni_ImageGeneric_setArrayByte(JNIEnv *env, jobject jobj,
 
         switch (dataType)
     {
+    case DT_UHalfByte:
     case DT_UChar:
         {
             unsigned char *mdarray;

--- a/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.h
+++ b/software/em/xmipp/libraries/bindings/java/xmipp_ImageGeneric.h
@@ -33,24 +33,28 @@ extern "C" {
 #define xmipp_ImageGeneric_UInt 5L
 #undef xmipp_ImageGeneric_Int
 #define xmipp_ImageGeneric_Int 6L
+#undef xmipp_ImageGeneric_ULong
+#define xmipp_ImageGeneric_ULong 7L
 #undef xmipp_ImageGeneric_Long
-#define xmipp_ImageGeneric_Long 7L
+#define xmipp_ImageGeneric_Long 8L
 #undef xmipp_ImageGeneric_Float
-#define xmipp_ImageGeneric_Float 8L
+#define xmipp_ImageGeneric_Float 9L
 #undef xmipp_ImageGeneric_Double
-#define xmipp_ImageGeneric_Double 9L
+#define xmipp_ImageGeneric_Double 10L
 #undef xmipp_ImageGeneric_ComplexShort
-#define xmipp_ImageGeneric_ComplexShort 10L
+#define xmipp_ImageGeneric_ComplexShort 11L
 #undef xmipp_ImageGeneric_ComplexInt
-#define xmipp_ImageGeneric_ComplexInt 11L
+#define xmipp_ImageGeneric_ComplexInt 12L
 #undef xmipp_ImageGeneric_ComplexFloat
-#define xmipp_ImageGeneric_ComplexFloat 12L
+#define xmipp_ImageGeneric_ComplexFloat 13L
 #undef xmipp_ImageGeneric_ComplexDouble
-#define xmipp_ImageGeneric_ComplexDouble 13L
+#define xmipp_ImageGeneric_ComplexDouble 14L
 #undef xmipp_ImageGeneric_Bool
-#define xmipp_ImageGeneric_Bool 14L
+#define xmipp_ImageGeneric_Bool 15L
+#undef xmipp_ImageGeneric_UHalfByte
+#define xmipp_ImageGeneric_UHalfByte 16L
 #undef xmipp_ImageGeneric_LastEntry
-#define xmipp_ImageGeneric_LastEntry 15L
+#define xmipp_ImageGeneric_LastEntry 17L
 /*
  * Class:     xmipp_ImageGeneric
  * Method:    create

--- a/software/em/xmipp/libraries/data/rwMRC.cpp
+++ b/software/em/xmipp/libraries/data/rwMRC.cpp
@@ -189,7 +189,6 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
     }
 
     DataType datatype;
-    std::cerr << " header->mode" << header->mode << std::endl;
     switch ( header->mode )
     {
     case 0:
@@ -228,7 +227,7 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
     size_t datasize_n;
     datasize_n = _xDim*_yDim*_zDim;
 
-    // If mode are fourier transforms (3,4)
+    // If mode is any of the fourier transforms (3,4)
     if ( header->mode > 2 && header->mode < 5 )
     {
         transform = CentHerm;
@@ -315,11 +314,9 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
 
     // 4-bits mode: Here is the magic to expand the compressed images
     if (datatype == DT_UHalfByte){
-        std::cout << "mrc_io-readdata4BIT" << std::endl;
         readData4bit(fimg, select_img, datatype, 0);
     }
     else{
-        std::cout << "mrc_io-readdata" << std::endl;
         readData(fimg, select_img, datatype, 0);
     }
 

--- a/software/em/xmipp/libraries/data/rwMRC.cpp
+++ b/software/em/xmipp/libraries/data/rwMRC.cpp
@@ -313,12 +313,14 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
     // Lets read the data
 
     // 4-bits mode: Here is the magic to expand the compressed images
-    if (header->mode == 101)
+    if (header->mode == 101){
         std::cout << "readData4bit" << header->mode << " " << std::endl;
         readData4bit(fimg, select_img, datatype, 0);
-    else
+    }
+    else{
         std::cout << "readData" << header->mode << " " << std::endl;
         readData(fimg, select_img, datatype, 0);
+    }
 
     return errCode;
 }

--- a/software/em/xmipp/libraries/data/rwMRC.cpp
+++ b/software/em/xmipp/libraries/data/rwMRC.cpp
@@ -123,7 +123,7 @@ struct MRChead
 int ImageBase::readMRC(size_t select_img, bool isStack)
 {
 #undef DEBUG
-    #define DEBUG
+    //#define DEBUG
 #ifdef DEBUG
     printf("DEBUG readMRC: Reading MRC file\n");
 #endif
@@ -314,11 +314,9 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
 
     // 4-bits mode: Here is the magic to expand the compressed images
     if (header->mode == 101){
-        std::cout << "readData4bit" << header->mode << " " << std::endl;
         readData4bit(fimg, select_img, datatype, 0);
     }
     else{
-        std::cout << "readData" << header->mode << " " << std::endl;
         readData(fimg, select_img, datatype, 0);
     }
 

--- a/software/em/xmipp/libraries/data/rwMRC.cpp
+++ b/software/em/xmipp/libraries/data/rwMRC.cpp
@@ -189,6 +189,7 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
     }
 
     DataType datatype;
+    std::cerr << " header->mode" << header->mode << std::endl;
     switch ( header->mode )
     {
     case 0:
@@ -313,10 +314,12 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
     // Lets read the data
 
     // 4-bits mode: Here is the magic to expand the compressed images
-    if (header->mode == 101){
+    if (datatype == DT_UHalfByte){
+        std::cout << "mrc_io-readdata4BIT" << std::endl;
         readData4bit(fimg, select_img, datatype, 0);
     }
     else{
+        std::cout << "mrc_io-readdata" << std::endl;
         readData(fimg, select_img, datatype, 0);
     }
 

--- a/software/em/xmipp/libraries/data/rwMRC.cpp
+++ b/software/em/xmipp/libraries/data/rwMRC.cpp
@@ -314,8 +314,10 @@ int ImageBase::readMRC(size_t select_img, bool isStack)
 
     // 4-bits mode: Here is the magic to expand the compressed images
     if (header->mode == 101)
+        std::cout << "readData4bit" << header->mode << " " << std::endl;
         readData4bit(fimg, select_img, datatype, 0);
     else
+        std::cout << "readData" << header->mode << " " << std::endl;
         readData(fimg, select_img, datatype, 0);
 
     return errCode;

--- a/software/em/xmipp/libraries/data/xmipp_datatype.cpp
+++ b/software/em/xmipp/libraries/data/xmipp_datatype.cpp
@@ -80,16 +80,6 @@ size_t gettypesize(DataType type)
     return(size);
 }
 
-// Get size of datatype at reading time
-size_t getreadtypesize(DataType type)
-{
-
-    if (type == DT_UHalfByte)
-        return (size_t) 0.5;
-    else
-        return gettypesize(type);
-}
-
 /** Convert datatype string to datatypr enun */
 DataType str2Datatype(const std::string & str)
 {

--- a/software/em/xmipp/libraries/data/xmipp_datatype.cpp
+++ b/software/em/xmipp/libraries/data/xmipp_datatype.cpp
@@ -85,7 +85,7 @@ size_t getreadtypesize(DataType type)
 {
 
     if (type == DT_UHalfByte)
-        return (size_t) 4;
+        return (size_t) 0.5;
     else
         return gettypesize(type);
 }

--- a/software/em/xmipp/libraries/data/xmipp_datatype.h
+++ b/software/em/xmipp/libraries/data/xmipp_datatype.h
@@ -61,9 +61,6 @@ typedef enum
 /// Returns memory size of datatype
 size_t gettypesize(DataType type);
 
-/// Returns size of a datatype at reading time
-size_t getreadtypesize(DataType type);
-
 /** Convert datatype string to datatype enum */
 DataType str2Datatype(const std::string & str);
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1420,6 +1420,15 @@ private:
                 page[i+1] = value >> 4; // take the upper 4 bits
             }
 
+
+            for (size_t i = 0; i<10; ++i)
+            {
+                for (size_t j = 0; j<10; ++j)
+                {
+                    std::cout<<(unsigned char) page[i*7676+j]<<" ";
+                }
+                std::cout<<std::endl;
+            }
             castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, datatype,
                        pagesizeM);
             haveread_n += pagesizeM;

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -193,7 +193,14 @@ public:
                 {
                     unsigned char * ptr = (unsigned char *) page;
                     for (size_t i = 0; i < pageSize; ++i, ++ptr)
+                    {
                         ptrDest[i] = (T) *ptr;
+
+                        if (ptrDest[i] > 15)
+                            std::cout<<"*ptr= "<< *ptr <<"; ptrDest = "<< ptrDest[i]<<"; char *ptr = "<< (char) *ptr;
+
+                    }
+
                 }
                 break;
             }
@@ -1375,8 +1382,6 @@ private:
         if (datatype != DT_UHalfByte){
             REPORT_ERROR(ERR_MMAP, "Image Class::readData4bit  not supported for  "
                                    "data type different than " + datatype2Str(DT_UHalfByte));
-        } else {
-            datatype = DT_UChar;
         }
 
         size_t selectImgOffset; //4Mb
@@ -1419,13 +1424,9 @@ private:
                 page[i] = value & mask; // take the lower 4 bits
                 page[i+1] = value >> 4; // take the upper 4 bits
 
-                if (page[i] > 15)
-                    std::cout<<"Page i = "<< i<<"= "<< page[i];
-                if (page[i+1] > 15)
-                    std::cout<<"Page i+1 = "<< i+1<<"= "<< page[i+1];
             }
 
-            castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, DT_SChar,
+            castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, datatype,
                        pagesizeM);
             haveread_n += pagesizeM;
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1381,7 +1381,6 @@ private:
 
         size_t selectImgOffset; //4Mb
         size_t itemSize = ZYXSIZE(data);
-        size_t itemSizeHalf = itemSize/2;
         size_t pagesizeF = itemSize /2;
         size_t pagesizeM = itemSize;
         //size_t pagesizeHalf = pagesize/2;
@@ -1411,7 +1410,7 @@ private:
 
             // cast to T per page
 
-            size_t start = itemSizeF;
+            size_t start = pagesizeF;
             uint8_t mask = 15; // 00001111
 
             for (size_t i = 0, j = start; i < itemSizeM - 1; i += 2, ++j)

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1439,7 +1439,7 @@ private:
 #endif
         }
         if (page > 0)
-            freeMemory(page, pagesize * sizeof(char));
+            freeMemory(page, pagesizeM * sizeof(char));
 
         return;
     }

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -188,19 +188,12 @@ public:
             case DT_UChar:
             {
                 if (typeid(T) == typeid(unsigned char))
-                {
                     memcpy(ptrDest, page, pageSize * sizeof(T));
-                }
-
                 else
                 {
                     unsigned char * ptr = (unsigned char *) page;
                     for (size_t i = 0; i < pageSize; ++i, ++ptr)
-                    {
                         ptrDest[i] = (T) *ptr;
-
-                    }
-
                 }
                 break;
             }
@@ -1409,8 +1402,6 @@ private:
         for (size_t myn = 0; myn < NSIZE(data); myn++)
         {
 
-            //std::cout<<"ww: " << page+pagesizeHalf<<" "<<pagesizeHalf<<std::endl;
-
             //Read page from disc
             if (fread(page+pagesizeF, pagesizeF, 1, fimg) != 1)
                 REPORT_ERROR(ERR_IO_NOREAD, "Cannot read the whole page");
@@ -1425,7 +1416,6 @@ private:
                 char& value = *(page+j);
                 page[i] = value & mask; // take the lower 4 bits
                 page[i+1] = (value >> 4) & mask; // take the upper 4 bits
-
             }
 
             castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, datatype,

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -202,7 +202,7 @@ public:
                         ptrDest[i] = (T) *ptr;
 
                         if (ptrDest[i] > 15)
-                            std::cout<<"*ptr= "<< *ptr <<"; ptrDest = "<< ptrDest[i]<<"; char *ptr = "<< (char) *ptr;
+                            std::cout<<"*ptr= "<< (int)*ptr <<"; ptrDest = "<< (int)ptrDest[i]<<"; char *ptr = "<< (int) *ptr<<std::endl;
 
                     }
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1255,8 +1255,10 @@ private:
             return;
 
         if (datatype == DT_UHalfByte){
-            REPORT_ERROR(ERR_MMAP, "Image Class::readData not supported for  "
-                                   "data type " + datatype2Str(DT_UHalfByte));
+            //REPORT_ERROR(ERR_MMAP, "Image Class::readData not supported for  "
+            //                       "data type " + datatype2Str(DT_UHalfByte));
+            std::out<<"redirecting from readData to readData4bits!"<<std::endl;
+            readData4bit(fimg, select_img, datatype, pad);
         }
         // If only half of a transform is stored, it needs to be handled
         if (transform == Hermitian || transform == CentHerm)

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -187,22 +187,17 @@ public:
             case DT_UHalfByte:
             case DT_UChar:
             {
-                if (typeid(T) != typeid(unsigned char))
+                if (typeid(T) == typeid(unsigned char))
                 {
-                    std::cout<<"HOlaaaa if";
                     memcpy(ptrDest, page, pageSize * sizeof(T));
                 }
 
                 else
                 {
-                    std::cout<<"HOlaaaa else";
                     unsigned char * ptr = (unsigned char *) page;
                     for (size_t i = 0; i < pageSize; ++i, ++ptr)
                     {
                         ptrDest[i] = (T) *ptr;
-
-                        if (ptrDest[i] > 15)
-                            std::cout<<"*ptr= "<< (int)*ptr <<"; ptrDest = "<< (int)ptrDest[i]<<"; char *ptr = "<< (int) *ptr<<std::endl;
 
                     }
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1405,7 +1405,7 @@ private:
         selectImgOffset = offset + IMG_INDEX(select_img) * (pagesizeF + pad);
 
         if (fseek(fimg, selectImgOffset, SEEK_SET) == -1)
-            REPORT_ERROR(ERR_IO_SIZE, "readData: can not seek the file pointer");
+            REPORT_ERROR(ERR_IO_SIZE, "readData4bit: can not seek the file pointer");
         for (size_t myn = 0; myn < NSIZE(data); myn++)
         {
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1427,7 +1427,7 @@ private:
             {
                 char& value = *(page+j);
                 page[i] = value & mask; // take the lower 4 bits
-                page[i+1] = value >> 4; // take the upper 4 bits
+                page[i+1] = (value >> 4) & mask; // take the upper 4 bits
 
             }
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1257,7 +1257,7 @@ private:
         if (datatype == DT_UHalfByte){
             //REPORT_ERROR(ERR_MMAP, "Image Class::readData not supported for  "
             //                       "data type " + datatype2Str(DT_UHalfByte));
-            std::out<<"redirecting from readData to readData4bits!"<<std::endl;
+            std::cout<<"redirecting from readData to readData4bits!"<<std::endl;
             readData4bit(fimg, select_img, datatype, pad);
         }
         // If only half of a transform is stored, it needs to be handled

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1429,7 +1429,7 @@ private:
                 }
                 std::cout<<std::endl;
             }
-            castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, datatype,
+            castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, DT_SChar,
                        pagesizeM);
             haveread_n += pagesizeM;
 

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1418,14 +1418,19 @@ private:
                 char& value = *(page+j);
                 page[i] = value & mask; // take the lower 4 bits
                 page[i+1] = value >> 4; // take the upper 4 bits
+
+                if (page[i] > 15)
+                    std::cout<<"Page i = "<< i<<"= "<< page[i];
+                if (page[i+1] > 15)
+                    std::cout<<"Page i+1 = "<< i+1<<"= "<< page[i+1];
             }
 
 
-            for (size_t i = 0; i<10; ++i)
+            for (size_t i = 0; i<7420; ++i)
             {
-                for (size_t j = 0; j<10; ++j)
+                for (size_t j = 0; j<; ++j)
                 {
-                    std::cout<<(unsigned int) page[i*7676+j]<<" ";
+
                 }
                 std::cout<<std::endl;
             }

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1399,7 +1399,7 @@ private:
         for (size_t myn = 0; myn < NSIZE(data); myn++)
         {
 
-            std::cout<<page+pagesizeHalf<<" "<<pagesizeHalf<<std::endl;
+            std::cout<<"ww: " << page+pagesizeHalf<<" "<<pagesizeHalf<<std::endl;
 
             //Read page from disc
             if (fread(page+pagesizeHalf, pagesizeHalf, 1, fimg) != 1)

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -187,7 +187,7 @@ public:
             case DT_UHalfByte:
             case DT_UChar:
             {
-                if (typeid(T) == typeid(unsigned char))
+                if (typeid(T) != typeid(unsigned char))
                 {
                     std::cout<<"HOlaaaa if";
                     memcpy(ptrDest, page, pageSize * sizeof(T));

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -188,9 +188,14 @@ public:
             case DT_UChar:
             {
                 if (typeid(T) == typeid(unsigned char))
+                {
+                    std::cout<<"HOlaaaa if";
                     memcpy(ptrDest, page, pageSize * sizeof(T));
+                }
+
                 else
                 {
+                    std::cout<<"HOlaaaa else";
                     unsigned char * ptr = (unsigned char *) page;
                     for (size_t i = 0; i < pageSize; ++i, ++ptr)
                     {

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1425,15 +1425,6 @@ private:
                     std::cout<<"Page i+1 = "<< i+1<<"= "<< page[i+1];
             }
 
-
-            for (size_t i = 0; i<7420; ++i)
-            {
-                for (size_t j = 0; j<; ++j)
-                {
-
-                }
-                std::cout<<std::endl;
-            }
             castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, DT_SChar,
                        pagesizeM);
             haveread_n += pagesizeM;

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1425,7 +1425,7 @@ private:
             {
                 for (size_t j = 0; j<10; ++j)
                 {
-                    std::cout<<(unsigned char) page[i*7676+j]<<" ";
+                    std::cout<<(unsigned int) page[i*7676+j]<<" ";
                 }
                 std::cout<<std::endl;
             }

--- a/software/em/xmipp/libraries/data/xmipp_image.h
+++ b/software/em/xmipp/libraries/data/xmipp_image.h
@@ -1413,7 +1413,7 @@ private:
             size_t start = pagesizeF;
             uint8_t mask = 15; // 00001111
 
-            for (size_t i = 0, j = start; i < itemSizeM - 1; i += 2, ++j)
+            for (size_t i = 0, j = start; i < pagesizeM - 1; i += 2, ++j)
             {
                 char& value = *(page+j);
                 page[i] = value & mask; // take the lower 4 bits
@@ -1421,8 +1421,8 @@ private:
             }
 
             castPage2T(page, MULTIDIM_ARRAY(data) + haveread_n, datatype,
-                       itemSizeM);
-            haveread_n += itemSizeM;
+                       pagesizeM);
+            haveread_n += pagesizeM;
 
             if (pad > 0)
                 //fread( padpage, pad, 1, fimg);

--- a/software/em/xmipp/libraries/data/xmipp_image_base.cpp
+++ b/software/em/xmipp/libraries/data/xmipp_image_base.cpp
@@ -749,7 +749,7 @@ int ImageBase::_read(const FileName &name, ImageFHandler* hFile, DataMode datamo
         err = readTIA(select_img,false);
     else if (ext_name.contains("dm3"))//DM3
         err = readDM3(select_img,false);
-    else if (ext_name.contains("dm4"))//DM3
+    else if (ext_name.contains("dm4"))//DM4
         err = readDM4(select_img,false);
     else if (ext_name.contains("ems"))//EM stack
         err = readEM(select_img, true);


### PR DESCRIPTION
Enable Scipion/xmipp to read mrc4 bits and visualise them
Handle Java max memory (2Gb) by default +1 (3GB) for set of movies. 
If JAVA_MAX_MEMORY in the config it will be taken into account.