### PR TITLE
CRITICAL visualization BUG in release-1.2.1

### DIFF
--- a/pyworkflow/em/packages/relion/viewer.py
+++ b/pyworkflow/em/packages/relion/viewer.py
@@ -649,7 +649,6 @@ Examples:
 #===============================================================================
     def _showFSC(self, paramName=None):
         #self._iterations = self._getListFromRangeString(self.iterSelection.get())
-        print("_showFSC_self._iterations",self._iterations)
         threshold = self.resolutionThresholdFSC.get()
         prefixes = self._getPrefixes()        
         nrefs = len(self._refsList)

--- a/pyworkflow/em/packages/xmipp3/protocol_particle_pick.py
+++ b/pyworkflow/em/packages/xmipp3/protocol_particle_pick.py
@@ -69,7 +69,7 @@ class XmippProtParticlePicking(ProtParticlePicking, XmippProtocol):
     def launchParticlePickGUIStep(self, micFn):
         # Launch the particle picking GUI
         extraDir = self._getExtraPath()
-        memory = '%dg'%self.memory.get()
+        memory = '%d' % self.memory.get()
         process = launchSupervisedPickerGUI(micFn, extraDir, self, memory=memory)
         process.wait()
 

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -328,10 +328,11 @@ class XmippViewer(Viewer):
                 inTmpFolder = True
 
             posDir = obj._getExtraPath()
-            memory = '%dg'%obj.memory.get(),
-            launchSupervisedPickerGUI(micsfn, posDir, obj, mode='review', memory=memory, inTmpFolder=inTmpFolder)
+            memory = '%d' % obj.memory.get()
+            launchSupervisedPickerGUI(micsfn, posDir, obj, mode='review',
+                                      memory=memory, inTmpFolder=inTmpFolder)
 
-         # We need this case to happens before the ProtParticlePicking one
+        # We need this case to happens before the ProtParticlePicking one
         elif issubclass(cls, XmippProtAssignmentTiltPair):
             if obj.getOutputsSize() >= 1:
                 coordsSet = obj.getCoordsTiltPair()

--- a/pyworkflow/em/protocol/protocol_align_movies.py
+++ b/pyworkflow/em/protocol/protocol_align_movies.py
@@ -52,7 +52,7 @@ class ProtAlignMovies(ProtProcessMovies):
     or the cropping options (region of interest)
     """
 
-    #--------------------------- DEFINE param functions ------------------------
+    # -------------------------- DEFINE param functions -----------------------
     def _defineParams(self, form):
         ProtProcessMovies._defineParams(self, form)
         self._defineAlignmentParams(form)
@@ -105,7 +105,6 @@ class ProtAlignMovies(ProtProcessMovies):
                       help="Save Aligned movie")
 
     # --------------------------- STEPS functions ----------------------------
-
     # FIXME: Methods will change when using the streaming for the output
     def createOutputStep(self):
         # validate that we have some output movies
@@ -190,9 +189,9 @@ class ProtAlignMovies(ProtProcessMovies):
                 if newMovie.getAlignment().getShifts()[0]:
                     movieSet.append(newMovie)
                 else:
-                    print(yellowStr("WARNING: Movie %s has empty alignment data, can't add it to "
-                                    "output set." % movie.getFileName()))
-
+                    print(yellowStr("WARNING: Movie %s has empty alignment "
+                                    "data, can't add it to output set."
+                                    % movie.getFileName()))
 
             self._updateOutputSet('outputMovies', movieSet, streamMode)
 
@@ -205,7 +204,6 @@ class ProtAlignMovies(ProtProcessMovies):
                 if not saveMovie:
                     movieSet.setDim(self.inputMovies.get().getDim())
                 self._defineTransformRelation(self.inputMovies, movieSet)
-
 
         def _updateOutputMicSet(sqliteFn, getOutputMicName, outputName):
             """ Updated the output micrographs set with new items found. """
@@ -221,8 +219,8 @@ class ProtAlignMovies(ProtProcessMovies):
                 extraMicFn = self._getExtraPath(getOutputMicName(movie))
                 mic.setFileName(extraMicFn)
                 if not os.path.exists(extraMicFn):
-                    print(yellowStr("WARNING: Micrograph %s was not generated, can't add it to "
-                                    "output set." % extraMicFn))
+                    print(yellowStr("WARNING: Micrograph %s was not generated, "
+                                    "can't add it to output set." % extraMicFn))
                     doneFailed.append(movie)
                     continue
                 self._preprocessOutputMicrograph(mic, movie)
@@ -255,7 +253,6 @@ class ProtAlignMovies(ProtProcessMovies):
                 outputStep.setStatus(cons.STATUS_NEW)
 
     # --------------------------- INFO functions ------------------------------
-
     def _validate(self):
         errors = []
 
@@ -314,7 +311,6 @@ class ProtAlignMovies(ProtProcessMovies):
         return errors
 
     # --------------------------- INFO functions -------------------------------
-
     def _summary(self):
         return [self.summaryVar.get('')]
 
@@ -388,7 +384,6 @@ class ProtAlignMovies(ProtProcessMovies):
         return alignedMovie
 
     # ---------- Hook functions that need to be implemented in subclasses ------
-
     def _getBinFactor(self):
         return self.getAttributeValue('binFactor', 1.0)
 
@@ -671,7 +666,7 @@ class ProtAverageFrames(ProtAlignMovies):
     """
     _label = 'average frames'
 
-    #--------------------------- DEFINE param functions ------------------------
+    # -------------------------- DEFINE param functions -----------------------
     def _defineAlignmentParams(self, form):
         pass
 

--- a/pyworkflow/em/showj.py
+++ b/pyworkflow/em/showj.py
@@ -230,7 +230,8 @@ class ColumnProperties():
                 'columnName': self.getName(),
                 'columnLabel': self.getLabel()
                 }
-        
+
+
 def getArchitecture():
     import platform
     arch = platform.architecture()[0]
@@ -238,7 +239,8 @@ def getArchitecture():
         if a in arch:
             return a
     return 'NO_ARCH' 
-    
+
+
 def getJavaIJappArguments(memory, appName, appArgs):
     """ Build the command line arguments to launch 
     a Java application based on ImageJ. 
@@ -248,7 +250,7 @@ def getJavaIJappArguments(memory, appName, appArgs):
     """ 
     if memory is None:
         memory = getJvmMaxMemory()
-        print "No memory size provided. Using default: " + memory
+        print "No memory size provided. Using default: %s" % memory
     
     jdkLib = join(os.environ['JAVA_HOME'], 'lib')
     imagej_home = join(os.environ['XMIPP_HOME'], "external", "imagej")
@@ -260,15 +262,17 @@ def getJavaIJappArguments(memory, appName, appArgs):
 
     return args
 
+
 def runJavaIJapp(memory, appName, args, env={}):
     from pyworkflow.em.packages import xmipp3
     env.update(xmipp3.getEnviron(xmippFirst=False))
 
     args = getJavaIJappArguments(memory, appName, args)
-    print 'java %s'%args
+    print 'java %s' % args
     #return subprocess.Popen('java ' + args, shell=True, env=env)
     cmd = ['java'] + shlex.split(args)
     return subprocess.Popen(cmd, env=env)
+
 
 def launchSupervisedPickerGUI(micsFn, outputDir, protocol, mode=None,
                               memory=None, pickerProps=None, inTmpFolder=False):
@@ -319,7 +323,8 @@ class ProtocolTCPRequestHandler(SocketServer.BaseRequestHandler):
         else:
             answer = 'no answer available'
             self.request.sendall(answer + '\n')
-    
+
+
 class MySocketServer (SocketServer.TCPServer):
 
     def serve_forever(self):


### PR DESCRIPTION
There is a very important bug introduced in #1693 that stop visuazliations to show up mainly for coordinates and some other cases. 

@pconesa and @rmarabini , I think you should have been more careful with the changes introduced in the Java memory param, it was changed from integer to string, but all the cases were not tested. It was not even basically tested that most common showj use cases were working!!! I think we should avoid this issues, specially for a release that is about to be out. You "fixed" the case for visualizing movies, that is not commonly used...and you broke the Xmipp picker, coordinates visualization and other cases.

I will take also my part of responsibility, since I reviewed this PR and this issue passed. The other problem, is this original PR was about DM4 support, which I tested...and this "minor change" in Java viewer was also introduced here. We should try to avoid this in the future and restrict a PR to a main change. 