### PR TITLE
add new eman-related imports; add coord pairs import

### DIFF
--- a/pyworkflow/em/protocol/protocol_import/__init__.py
+++ b/pyworkflow/em/protocol/protocol_import/__init__.py
@@ -30,7 +30,7 @@ of objects.
 """
 
 from base import ProtImport, ProtImportFiles
-from coordinates import ProtImportCoordinates
+from coordinates import ProtImportCoordinates, ProtImportCoordinatesPairs
 from ctfs import ProtImportCTF
 from images import ProtImportImages
 from masks import ProtImportMask

--- a/pyworkflow/em/protocol/protocol_import/coordinates.py
+++ b/pyworkflow/em/protocol/protocol_import/coordinates.py
@@ -1,8 +1,10 @@
 # **************************************************************************
 # *
-# * Authors:     J.M. De la Rosa Trevin (delarosatrevin@scilifelab.se) [1]
+# * Authors:     J.M. De la Rosa Trevin (jmdelarosa@cnb.csic.es) [1]
+# * Authors:     Grigory Sharov (gsharov@mrc-lmb.cam.ac.uk) [2]
 # *
-# * [1] SciLifeLab, Stockholm University
+# * [1] Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# * [2] MRC Laboratory of Molecular Biology (MRC-LMB)
 # *
 # * This program is free software; you can redistribute it and/or modify
 # * it under the terms of the GNU General Public License as published by
@@ -25,9 +27,16 @@
 # **************************************************************************
 
 from os.path import join, exists
+from glob import glob
+from itertools import izip
 
-from pyworkflow.protocol.params import IntParam, PointerParam, FloatParam, BooleanParam
-from pyworkflow.utils.path import removeBaseExt
+from pyworkflow.em import metadata as md
+from pyworkflow.protocol.params import (IntParam, PointerParam, FloatParam,
+                                        BooleanParam, PathParam, EnumParam,
+                                        LEVEL_ADVANCED)
+from pyworkflow.utils.path import removeBaseExt, expandPattern
+from pyworkflow.utils.properties import Message
+from pyworkflow.em.data_tiltpairs import CoordinatesTiltPair
 from pyworkflow.em.protocol import ProtParticlePicking
 from pyworkflow.utils import importFromPlugin
 import xmippLib
@@ -53,14 +62,14 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
 
     def _getDefaultChoice(self):
         return self.IMPORT_FROM_AUTO
-    
+
     def _getFilesCondition(self):
         """ Return an string representing the condition
         when to display the files path and pattern to grab
         files.
         """
         return True
-    
+
     # ---------------------- DEFINE param functions ---------------------------
     def _defineParams(self, form):
 
@@ -89,7 +98,7 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
     def _insertAllSteps(self):
         importFrom = self.importFrom.get()
         self._insertFunctionStep('createOutputStep', importFrom,
-                                     self.filesPath.get())
+                                 self.filesPath.get())
 
     # ------------------ STEPS functions --------------------------------------
     def createOutputStep(self, importFrom, *args):
@@ -98,7 +107,7 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
         coordsSet.setBoxSize(self.boxSize.get())
         ci = self.getImportClass()
         for coordFile, fileId in self.iterFiles():
-            mic = self.getMatchingMic(coordFile,fileId)
+            mic = self.getMatchingMic(coordFile, fileId)
             if mic is not None:
                 def addCoordinate(coord):
                     coord.setMicrograph(mic)
@@ -106,7 +115,7 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
                     coordsSet.append(coord)
                 # Parse the coordinates in the given format for this micrograph
                 ci.importCoordinates(coordFile, addCoordinate=addCoordinate)
-        
+
         self._defineOutputs(outputCoordinates=coordsSet)
         self._defineSourceRelation(self.inputMicrographs, coordsSet)
 
@@ -134,13 +143,13 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
 
     def _methods(self):
         return self._summary()
-    
+
     # ------------------ UTILS functions --------------------------------------
     def getImportClass(self):
         """ Return the class in charge of importing the files. """
         filesPath = self.filesPath.get()
         importFrom = self.getImportFrom()
-        
+
         if importFrom == self.IMPORT_FROM_XMIPP:
             XmippImport = importFromPlugin('xmipp3.convert', 'XmippImport',
                                            'Xmipp is needed to import .xmd files',
@@ -149,33 +158,33 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
 
         elif importFrom == self.IMPORT_FROM_RELION:
             RelionImport = importFromPlugin('relion.convert', 'RelionImport',
-                              errorMsg='Relion is needed to import .star files',
-                              doRaise=True)
+                                            errorMsg='Relion is needed to import .star files',
+                                            doRaise=True)
             return RelionImport(self, filesPath)
-        
+
         elif importFrom == self.IMPORT_FROM_EMAN:
             EmanImport = importFromPlugin('eman2.convert', 'EmanImport',
-                                 errorMsg='Eman is needed to import .json or '
-                                          '.box files',
-                                 doRaise=True)
-            return EmanImport(self)
-        
+                                          errorMsg='Eman is needed to import .json or '
+                                                   '.box files',
+                                          doRaise=True)
+            return EmanImport(self, None)
+
         elif importFrom == self.IMPORT_FROM_DOGPICKER:
             DogpickerImport = importFromPlugin('appion.convert', 'DogpickerImport',
-                                    errorMsg='appion plugin is needed to import '
-                                             'dogpicker files',
-                                    doRaise=True)
+                                               errorMsg='appion plugin is needed to import '
+                                                        'dogpicker files',
+                                               doRaise=True)
             return DogpickerImport(self)
         else:
             self.importFilePath = ''
             return None
-        
+
     def getImportFrom(self):
         importFrom = self.importFrom.get()
         if importFrom == self.IMPORT_FROM_AUTO:
             importFrom = self.getFormat()
         return importFrom
-    
+
     def getFormat(self):
         for coordFile, _ in self.iterFiles():
             if coordFile.endswith('.pos'):
@@ -188,13 +197,13 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
 
     def getInputMicrographs(self):
         return self.inputMicrographs.get()
-    
+
     def getMatchingMic(self, coordFile, fileId):
         """ Given a coordinates file check if there is a micrograph
-        that this files matches. 
+        that this files matches.
         """
         micSet = self.inputMicrographs.get()
-        
+
         if fileId is None:
             coordBase = removeBaseExt(coordFile)
             for mic in micSet:
@@ -205,7 +214,7 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
             return None
         else:
             return micSet[fileId]
-        
+
     def correctCoordinatePosition(self, coord):
         mic = coord.getMicrograph()
         scaleFactor = self.scale.get()
@@ -222,7 +231,7 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
             y = height - y
         coord.setX(x)
         coord.setY(y)
-        
+
     def getDefaultBoxSize(self):
         """ This function is used by the wizard to estimate the box size. """
         boxSize = None
@@ -231,25 +240,370 @@ class ProtImportCoordinates(ProtImportFiles, ProtParticlePicking):
             boxSize = ci.getBoxSize([f for f, _ in self.iterFiles()][0])
             if boxSize is not None and self.scale != 1.:
                 boxSize = int(boxSize * self.scale.get())
-        
-        return boxSize
-    
-        boxSize = 100
-        importFrom = self.getImportFrom()
-        scale = self.scale.get()
 
-        if importFrom == ProtImportCoordinates.IMPORT_FROM_XMIPP:
-            configfile = join(self.filesPath.get(), 'config.xmd')
-            existsConfig = exists(configfile)
-            if existsConfig:
-                md = xmippLib.MetaData('properties@' + configfile)
-                configobj = md.firstObject()
-                boxSize = md.getValue(xmippLib.MDL_PICKING_PARTICLE_SIZE, configobj)
-        if importFrom == ProtImportCoordinates.IMPORT_FROM_EMAN:
-            # Read the boxSize from the e2boxercache/base.json
-            jsonFnbase = join(self.filesPath.get(), 'e2boxercache', 'base.json')
-            loadJson = importFromPlugin('eman2', 'loadJson')
-            jsonBoxDict = loadJson(jsonFnbase)
-            boxSize = int(jsonBoxDict["box_size"])
-        boxSize = (int)(boxSize * scale)
         return boxSize
+
+
+class ProtImportCoordinatesPairs(ProtImportFiles):
+    """ Protocol to import a set of tilt pair coordinates """
+    _label = 'import coordinate pairs'
+
+    IMPORT_FROM_XMIPP = 0
+    IMPORT_FROM_EMAN = 1
+
+    def _getImportChoices(self):
+        """ Return a list of possible choices
+        from which the import can be done.
+        (usually packages formats such as: xmipp3, eman2..etc.)
+        """
+        return ['xmipp', 'eman']
+
+    def _getDefaultChoice(self):
+        return self.IMPORT_FROM_XMIPP
+
+    # --------------------------- DEFINE param functions ----------------------
+    def _defineParams(self, form):
+        importChoices = self._getImportChoices()
+
+        form.addSection(label='Import')
+        form.addParam('importFrom', EnumParam,
+                      choices=importChoices, default=self._getDefaultChoice(),
+                      label='Import from',
+                      help='Select the type of import.\n'
+                           '_Auto_ - detects coordinate file type by extension.\n'
+                           '_Xmipp_ - provide *.pos files\n'
+                           '_Eman_ - provide info/*.json files')
+        form.addParam('copyFiles', BooleanParam, default=False,
+                      expertLevel=LEVEL_ADVANCED,
+                      label="Copy files?",
+                      help="By default the files are not copied into the "
+                           "project to avoid data duplication and to save "
+                           "disk space. Instead of copying, symbolic links are "
+                           "created pointing to original files. This approach "
+                           "has the drawback that if the project is moved to "
+                           "another computer, the links need to be restored.")
+        form.addParam('xmippMdFn', PathParam, condition='importFrom==0',
+                      important=True,
+                      label='Micrograph .xmd file',
+                      help='Provide input_micrographs.xmd file that contains '
+                           'tilt angles information. This file is usually '
+                           'created alongside the coordinates.')
+        form.addParam('patternUntilted', PathParam, label=Message.LABEL_PATTERNU,
+                      help=Message.TEXT_PATTERN)
+        form.addParam('patternTilted', PathParam, label=Message.LABEL_PATTERNT,
+                      help=Message.TEXT_PATTERN)
+        form.addParam('inputMicrographsTiltedPair', PointerParam,
+                      pointerClass='MicrographsTiltPair',
+                      label='Input tilt pair micrographs',
+                      help='Select the tilt pair micrographs for which you want '
+                           'to import coordinates.')
+        form.addParam('boxSize', IntParam, label='Box size')
+        form.addParam('scale', FloatParam,
+                      label='Scale', default=1,
+                      help='Factor to scale coordinates')
+        form.addParam('invertX', BooleanParam, default=False,
+                      label='Invert X')
+        form.addParam('invertY', BooleanParam, default=False,
+                      label='Invert Y')
+
+    # --------------------------- INSERT steps functions ----------------------
+    def _insertAllSteps(self):
+        self.micsFn = self._getExtraPath('input_micrographs.xmd')
+        self._insertFunctionStep('createOutputStep')
+
+    # --------------------------- STEPS functions -----------------------------
+    def createOutputStep(self):
+        micTiltPairs = self.getInputMicrographs()
+        # Get the converted input micrographs in Xmipp format
+        writeSetOfMicrographsPairs = importFromPlugin('xmipp3.convert',
+                                                      'writeSetOfMicrographsPairs')
+        writeSetOfMicrographsPairs(micTiltPairs.getUntilted(),
+                                   micTiltPairs.getTilted(),
+                                   self.micsFn)
+        uCoordSet, tCoordSet, anglesSet = self.readCoordinates()
+        # Create CoordinatesTiltPair object
+        coordsSet = self._createCoordinatesTiltPair(micTiltPairs,
+                                                    uCoordSet, tCoordSet,
+                                                    anglesSet, suffix='')
+        self._defineOutputs(outputCoordinatesTiltPair=coordsSet)
+        self._defineSourceRelation(self.inputMicrographsTiltedPair, coordsSet)
+
+    # --------------------------- INFO functions ------------------------------
+    def _validate(self):
+        errors = []
+        if not self.patternUntilted.get() or not self.patternTilted.get():
+            errors.append(Message.ERROR_PATTERN_EMPTY)
+        else:
+            filePathsUntilted = glob(expandPattern(self.patternUntilted.get()))
+            filePathsTilted = glob(expandPattern(self.patternTilted.get()))
+
+            if len(filePathsUntilted) == 0 or len(filePathsTilted) == 0:
+                errors.append(Message.ERROR_PATTERN_FILES)
+
+        return errors
+
+    def _summary(self):
+        summary = []
+
+        if not hasattr(self, 'outputCoordinatesTiltPair'):
+            msg = 'Output tilt pair coordinates not ready yet'
+        else:
+            msg = "%s  coordinate pairs from micrographs %s were imported using %s format." % (
+                self.outputCoordinatesTiltPair.getSize(),
+                self.getObjectTag('inputMicrographsTiltedPair'),
+                self._getImportChoices()[self.importFrom.get()])
+            if self.scale.get() != 1.:
+                msg += " Scale factor %0.2f was applied." % self.scale
+            if self.invertX.get():
+                msg += " X coordinate was inverted."
+            if self.invertY.get():
+                msg += " Y coordinate was inverted."
+
+            summary.append(msg)
+            summary.append("Output coordinates: %s." % self.getObjectTag('outputCoordinatesTiltPair'))
+        return summary
+
+    def _methods(self):
+        return self._summary()
+
+    # --------------------------- UTILS functions -----------------------------
+    def getImportClass(self):
+        """ Return the class in charge of importing the files. """
+        importFrom = self.importFrom.get()
+
+        if importFrom == self.IMPORT_FROM_XMIPP:
+            XmippImport = importFromPlugin('xmipp3.convert', 'XmippImport',
+                                           'Xmipp is needed to import .xmd files',
+                                           doRaise=True)
+            return XmippImport(self, None)
+        else:  # import from EMAN
+            EmanImport = importFromPlugin('eman2.convert', 'EmanImport',
+                                          errorMsg='Eman is needed to import .json or '
+                                                   '.box files',
+                                          doRaise=True)
+            return EmanImport(self, None)
+
+    def getInputMicrographs(self):
+        return self.inputMicrographsTiltedPair.get()
+
+    def getMatchingCoord(self, micU, micT):
+        """ Given a pair of mics check if there are coordinates
+        that match.
+        """
+        mics = [micU, micT]
+        patterns = [self.patternUntilted.get(), self.patternTilted.get()]
+        coords = []
+
+        for mic, pattern in izip(mics, patterns):
+            micFnBase = removeBaseExt(mic.getFileName())
+            for coordFn in self._iterFiles(pattern):
+                if coordFn not in coords:
+                    coorBase = removeBaseExt(coordFn).replace('_info', '')
+                    if coorBase in micFnBase or micFnBase in coorBase:
+                        coords.append(coordFn)
+
+        if len(coords) == 2:
+            return coords[0], coords[1]
+        else:
+            return False, False
+
+    def correctCoordinatePosition(self, coord):
+        mic = coord.getMicrograph()
+        scaleFactor = self.scale.get()
+        x = coord.getX()
+        y = coord.getY()
+        if scaleFactor != 1.:
+            x = coord.getX() * scaleFactor
+            y = coord.getY() * scaleFactor
+        if self.invertX:
+            width = mic.getDim()[0]
+            x = width - x
+        if self.invertY:
+            height = mic.getDim()[1]
+            y = height - y
+        coord.setX(x)
+        coord.setY(y)
+
+    def getDefaultBoxSize(self):
+        """ This function is used by the wizard to estimate the box size. """
+        ci = self.getImportClass()
+        pattern = self.patternUntilted.get()
+        if hasattr(ci, 'getBoxSize'):
+            boxSize = ci.getBoxSize([f for f in self._iterFiles(pattern)][0])
+            if boxSize is not None and self.scale != 1.:
+                boxSize = int(boxSize * self.scale.get())
+            return boxSize
+
+        boxSize = 100
+        scale = self.scale.get()
+        boxSize = int(boxSize * scale)
+
+        return boxSize
+
+    def readCoordinates(self):
+        micTiltPairs = self.getInputMicrographs()
+        ci = self.getImportClass()
+        uSet = micTiltPairs.getUntilted()
+        tSet = micTiltPairs.getTilted()
+        # Create Untilted and Tilted SetOfCoordinates
+        uCoordSet = self._createSetOfCoordinates(uSet, suffix='Untilted')
+        tCoordSet = self._createSetOfCoordinates(tSet, suffix='Tilted')
+        anglesSet = self._createSetOfAngles()
+
+        def _importCoords(uCoordSet, tCoordSet):
+            for micU, micT in izip(uSet, tSet):
+                coordFnU, coordFnT = self.getMatchingCoord(micU, micT)
+                if coordFnU and coordFnT:
+
+                    def addCoordinateU(coord):
+                        coord.setMicrograph(micU)
+                        self.correctCoordinatePosition(coord)
+                        uCoordSet.append(coord)
+
+                    ci.importCoordinates(coordFnU, addCoordinate=addCoordinateU)
+
+                    def addCoordinateT(coord):
+                        coord.setMicrograph(micT)
+                        self.correctCoordinatePosition(coord)
+                        tCoordSet.append(coord)
+
+                    ci.importCoordinates(coordFnT, addCoordinate=addCoordinateT)
+
+                    def addAngles(ang):
+                        anglesSet.append(ang)
+
+                    if self.importFrom.get() == self.IMPORT_FROM_EMAN:
+                        ci.importAngles(coordFnT, addAngles=addAngles)
+
+        _importCoords(uCoordSet, tCoordSet)
+        boxSize = self.boxSize.get()
+        uCoordSet.setBoxSize(boxSize)
+        tCoordSet.setBoxSize(boxSize)
+
+        uCoordSet.write()
+        tCoordSet.write()
+
+        if self.importFrom.get() == self.IMPORT_FROM_XMIPP:
+            readAnglesFromMicrographs = importFromPlugin('xmipp3.convert',
+                                                         'readAnglesFromMicrographs')
+            if exists(self.xmippMdFn.get()):
+                checkAngles = self._compareMicPairs(self.xmippMdFn, uSet, tSet)
+                if checkAngles:
+                    readAnglesFromMicrographs(self.xmippMdFn, anglesSet)
+                else:
+                    self.warning('Angles for some micrographs were not found, '
+                                 'skipping angles import')
+            else:
+                self.warning('Micrograph xmd file not provided, so tilt angles will '
+                             'not be imported')
+        anglesSet.write()
+
+        return uCoordSet, tCoordSet, anglesSet
+
+    def _iterFiles(self, pattern):
+        filePaths = glob(expandPattern(pattern))
+        for fn in filePaths:
+            yield fn
+
+    def _compareMicPairs(self, micFn, uSet, tSet):
+        # compare micFn input file and input micsSet
+        micMd = md.MetaData(micFn)
+        micFnDict = {}
+        inputMicsDict = {}
+        XmippMdRow = importFromPlugin('xmipp3', 'XmippMdRow')
+        for objId in micMd:
+            row = XmippMdRow()
+            row.readFromMd(micMd, objId)
+            micUFn = removeBaseExt(row.getValue(md.MDL_MICROGRAPH))
+            micTFn = removeBaseExt(row.getValue(md.MDL_MICROGRAPH_TILTED))
+            micFnDict[micUFn] = micTFn
+
+        for micU, micT in izip(uSet, tSet):
+            inputMicsDict[removeBaseExt(micU.getFileName())] = removeBaseExt(micT.getFileName())
+
+        for micKey in inputMicsDict:
+            if micKey not in micFnDict:
+                return False
+        return True
+
+    # all funcs below are required for tilt picker to work properly
+
+    def __getOutputSuffix(self):
+        maxCounter = -1
+        for attrName, _ in self.iterOutputAttributes(CoordinatesTiltPair):
+            suffix = attrName.replace('outputCoordinatesTiltPair', '')
+            try:
+                counter = int(suffix)
+            except:
+                counter = 1  # when there is not number assume 1
+            maxCounter = max(counter, maxCounter)
+
+        return str(maxCounter + 1) if maxCounter > 0 else ''  # empty if not outputs
+
+    def getSummary(self, coordSet):
+        summary = []
+        summary.append("Number of particle pairs picked: %s" % coordSet.getSize())
+        summary.append("Particle size: %s" % coordSet.getBoxSize())
+        return "\n".join(summary)
+
+    def _getBoxSize(self):
+        """ Redefine this function to set a specific box size to the output
+        coordinates untilted and tilted.
+        """
+        return None
+
+    def _readAngles(self, micsFn, suffix=''):
+        # Read Angles from input micrographs
+        anglesSet = self._createSetOfAngles(suffix=suffix)
+        readAnglesFromMicrographs = importFromPlugin('xmipp3.convert',
+                                                     'readAnglesFromMicrographs')
+        readAnglesFromMicrographs(micsFn, anglesSet)
+        anglesSet.write()
+        return anglesSet
+
+    def _readCoordinates(self, coordsDir, suffix=''):
+        micTiltPairs = self.inputMicrographsTiltedPair.get()
+        uSuffix = 'Untilted' + suffix
+        tSuffix = 'Tilted' + suffix
+        uSet = micTiltPairs.getUntilted()
+        tSet = micTiltPairs.getTilted()
+        # Create Untilted and Tilted SetOfCoordinates
+        readSetOfCoordinates = importFromPlugin('xmipp3.convert',
+                                                'readSetOfCoordinates')
+        uCoordSet = self._createSetOfCoordinates(uSet, suffix=uSuffix)
+        readSetOfCoordinates(coordsDir, uSet, uCoordSet)
+        uCoordSet.write()
+        tCoordSet = self._createSetOfCoordinates(tSet, suffix=tSuffix)
+        readSetOfCoordinates(coordsDir, tSet, tCoordSet)
+        tCoordSet.write()
+        boxSize = self._getBoxSize()
+        if boxSize:
+            uCoordSet.setBoxSize(boxSize)
+            tCoordSet.setBoxSize(boxSize)
+
+        return uCoordSet, tCoordSet
+
+    def registerCoords(self, coordsDir, store=True, readFromExtra=True):
+        micTiltPairs = self.inputMicrographsTiltedPair.get()
+        suffix = self.__getOutputSuffix()
+
+        uCoordSet, tCoordSet = self._readCoordinates(coordsDir, suffix)
+
+        if readFromExtra:
+            micsFn = self._getExtraPath('input_micrographs.xmd')
+        else:
+            micsFn = self._getPath('input_micrographs.xmd')
+
+        anglesSet = self._readAngles(micsFn, suffix)
+        # Create CoordinatesTiltPair object
+        outputset = self._createCoordinatesTiltPair(micTiltPairs,
+                                                    uCoordSet, tCoordSet,
+                                                    anglesSet, suffix)
+        summary = self.getSummary(outputset)
+        outputset.setObjComment(summary)
+        outputName = 'outputCoordinatesTiltPair' + suffix
+        outputs = {outputName: outputset}
+        self._defineOutputs(**outputs)
+        self._defineSourceRelation(self.inputMicrographsTiltedPair, outputset)
+        if store:
+            self._store()

--- a/pyworkflow/em/protocol/protocol_import/ctfs.py
+++ b/pyworkflow/em/protocol/protocol_import/ctfs.py
@@ -45,7 +45,8 @@ class ProtImportCTF(ProtImportFiles):
     IMPORT_FROM_XMIPP3 = 1
     IMPORT_FROM_GRIGORIEFF = 2
     IMPORT_FROM_GCTF = 3
-    IMPORT_FROM_SCIPION = 4
+    IMPORT_FROM_EMAN2 = 4
+    IMPORT_FROM_SCIPION = 5
 
     #--------------------------- DEFINE param functions ------------------------
 
@@ -63,7 +64,7 @@ class ProtImportCTF(ProtImportFiles):
         from which the import can be done.
         (usually packages formats such as: xmipp3, eman2, relion...etc.
         """
-        return ['auto', 'xmipp', 'grigorieff', 'gctf', 'scipion']
+        return ['auto', 'xmipp', 'grigorieff', 'gctf', 'eman2', 'scipion']
 
     def _getDefaultChoice(self):
         return  self.IMPORT_FROM_AUTO
@@ -100,6 +101,9 @@ class ProtImportCTF(ProtImportFiles):
         elif importFrom == self.IMPORT_FROM_GCTF:
             GctfImportCTF = importFromPlugin('gctf.convert', 'GctfImportCTF', doRaise=True)
             return GctfImportCTF(self)
+        elif importFrom == self.IMPORT_FROM_EMAN2:
+            EmanImport = importFromPlugin('eman2.convert', 'EmanImport', doRaise=True)
+            return EmanImport(self, None)
         elif importFrom == self.IMPORT_FROM_SCIPION:
             from dataimport import ScipionImport
             return ScipionImport(self, self.filesPath.get('').strip())
@@ -221,13 +225,11 @@ class ProtImportCTF(ProtImportFiles):
     def getFormat(self):
         for fileName, _ in self.iterFiles():
             if (fileName.endswith('.log') or 
-                fileName.endswith('.txt') or
-                fileName.endswith('.out')):
+                    fileName.endswith('.txt') or
+                    fileName.endswith('.out')):
                 return self.IMPORT_FROM_GRIGORIEFF
             if fileName.endswith('.ctfparam'):
                 return self.IMPORT_FROM_XMIPP3
+            if fileName.endswith('.json'):
+                return self.IMPORT_FROM_EMAN2
         return -1
-
-
-
-

--- a/pyworkflow/em/protocol/protocol_import/particles.py
+++ b/pyworkflow/em/protocol/protocol_import/particles.py
@@ -46,9 +46,10 @@ class ProtImportParticles(ProtImportImages):
     IMPORT_FROM_RELION = 3
     IMPORT_FROM_SCIPION = 4
     IMPORT_FROM_FREALIGN = 5
+    IMPORT_FROM_EMAN = 6
 
-    importFormats = ['emx', 'xmipp3', 'relion', 'scipion', 'frealign']
-    importExts = ['emx', 'xmd', 'star', 'sqlite', 'par']
+    importFormats = ['emx', 'xmipp3', 'relion', 'scipion', 'frealign', 'eman']
+    importExts = ['emx', 'xmd', 'star', 'sqlite', 'par', 'lst']
     alignTypeList = [ALIGN_2D, ALIGN_3D, ALIGN_PROJ, ALIGN_NONE]
 
     def _getImportChoices(self):
@@ -74,31 +75,32 @@ class ProtImportParticles(ProtImportImages):
                        "*xmipp3*: images.xmd\n"
                        "*relion*: itXX_data.star\n"
                        "*scipion*: particles.sqlite\n"
+                       "*eman*: particleSet.lst\n"
                        "" % ', '.join(self.importFormats))
 
         form.addParam('emxFile', params.FileParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_EMX,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_EMX,
                       label='Input EMX file',
                       help="Select the EMX file containing particles "
                            "information.\n See more about \n"
                            "[[http://i2pc.cnb.csic.es/emx][EMX format]]")
 
         form.addParam('alignType', params.EnumParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_EMX,
-                      default = 0,
-                      choices =self.alignTypeList,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_EMX,
+                      default=0,
+                      choices=self.alignTypeList,
                       label='Alignment Type',
                       help="Is this a 2D alignment, a 3D alignment or a set of projections")
 #
         form.addParam('mdFile', params.FileParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_XMIPP3,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_XMIPP3,
                       label='Particles metadata file',
                       help="Select the particles Xmipp metadata file.\n"
                            "It is usually a images.xmd file result\n"
                            "from Xmipp protocols execution.")
         
         form.addParam('starFile', params.FileParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_RELION,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_RELION,
                       label='Star file',
                       help="Select a *_data.star file from a\n"
                            "previous Relion execution."
@@ -117,21 +119,25 @@ class ProtImportParticles(ProtImportImages):
                            "longer unique.")
         
         form.addParam('sqliteFile', params.FileParam,
-              condition = '(importFrom == %d)' % self.IMPORT_FROM_SCIPION,
+              condition='(importFrom == %d)' % self.IMPORT_FROM_SCIPION,
               label='Particles sqlite file',
               help="Select the particles sqlite file.\n")
 
         form.addParam('frealignLabel', params.LabelParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
                       label='For Frealign you need to import both stack and .par files.')  
         form.addParam('stackFile', params.FileParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
                       label='Stack file',
                       help="Select an stack file with the particles.")          
         form.addParam('parFile', params.FileParam,
-                      condition = '(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_FREALIGN,
                       label='Param file',
-                      help="Select a Frealign .par file with the refinement information.")        
+                      help="Select a Frealign .par file with the refinement information.")
+        form.addParam('lstFile', params.FileParam,
+                      condition='(importFrom == %d)' % self.IMPORT_FROM_EMAN,
+                      label='Lst file',
+                      help='Select a *.lst set file from EMAN2 project.')
         
         
     def _defineAcquisitionParams(self, form):
@@ -185,6 +191,11 @@ class ProtImportParticles(ProtImportImages):
                      doRaise=True)
             return GrigorieffLabImportParticles(self, self.parFile.get(),
                                                 self.stackFile.get())
+        elif self.importFrom == self.IMPORT_FROM_EMAN:
+            self.importFilePath = self.lstFile.get('').strip()
+            EmanImport = importFromPlugin('eman2.convert', 'EmanImport',
+                                          doRaise=True)
+            return EmanImport(self, self.lstFile.get())
         else:
             self.importFilePath = ''
             return None 

--- a/pyworkflow/em/wizard.py
+++ b/pyworkflow/em/wizard.py
@@ -29,7 +29,6 @@ This module implement some wizards
 """
 
 import os
-from os.path import basename, exists
 import Tkinter as tk
 import ttk
 
@@ -54,6 +53,7 @@ from pyworkflow.em.data import (Volume, SetOfMicrographs, SetOfParticles,
 from pyworkflow.em.protocol.protocol_import import (ProtImportImages,
                                                     ProtImportMovies,
                                                     ProtImportCoordinates,
+                                                    ProtImportCoordinatesPairs,
                                                     ProtImportVolumes)
 
 import xmippLib
@@ -855,7 +855,8 @@ class MaskRadiiPreviewDialog(MaskPreviewDialog):
 
 
 class ImportCoordinatesBoxSizeWizard(Wizard):
-    _targets = [(ProtImportCoordinates, ['boxSize'])]
+    _targets = [(ProtImportCoordinates, ['boxSize']),
+                (ProtImportCoordinatesPairs, ['boxSize'])]
 
     def _getBoxSize(self, protocol):
 

--- a/pyworkflow/tests/em/protocols/test_protocols_import_ctfs.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_import_ctfs.py
@@ -36,6 +36,7 @@ class TestImportCTFs(BaseTest):
         setupTestProject(cls)
         cls.dsXmipp = DataSet.getDataSet('xmipp_tutorial')
         cls.dsGrigorieff = DataSet.getDataSet('grigorieff')
+        cls.dsEman2 = DataSet.getDataSet('eman')
 
         # First, import a set of micrographs that will be used
         # from all ctf test cases
@@ -143,3 +144,15 @@ class TestImportCTFs(BaseTest):
 
         # The whole set (3 items) should find its corresponding CTF
         self.assertEqual(protCTF2.outputCTF.getSize(), 3)
+
+    def testImportEman2(self):
+        protCTF = self.newProtocol(ProtImportCTF,
+                                   importFrom=ProtImportCTF.IMPORT_FROM_EMAN2,
+                                   filesPath=self.dsEman2.getFile('ctfs'),
+                                   filesPattern='BPV*json')
+        protCTF.inputMicrographs.set(self.protImport.outputMicrographs)
+        protCTF.setObjLabel('import from eman2')
+        self.launchProtocol(protCTF)
+
+        self.assertIsNotNone(protCTF.outputCTF,
+                             "There was a problem when importing ctfs.")


### PR DESCRIPTION
These changes come from [EMAN2.21 PR](https://github.com/I2PC/scipion/pull/1616):

- new ProtImportCoordinatesPairs and a test
- imports from EMAN2: ctfs (json) + test, sets/particles (lst)

This closes #1500 