### PR TITLE
Set png library as default=True

### DIFF
--- a/install/script.py
+++ b/install/script.py
@@ -182,7 +182,7 @@ png = env.addLibrary(
     'png',
     tar='libpng-1.6.16.tgz',
     deps=[zlib],
-    default=False)
+    default=True)
 
 tiff = env.addLibrary(
      'tiff',


### PR DESCRIPTION
ShowJ uses png library, who depends on zlib. Then, if png isn't installed in Scipion, ShowJ find png in the system that can be incompatible with the zlib installed in Scipion by default and puted first in the LD_LIBRARY_PATH.