### PR TITLE
Fixed bug when gainImage is empty string

### DIFF
--- a/pyworkflow/em/protocol/protocol_movies.py
+++ b/pyworkflow/em/protocol/protocol_movies.py
@@ -152,8 +152,9 @@ class ProtProcessMovies(ProtPreprocessMicrographs):
         """ Returns the final path to the correction image (converted or not)
         or and exception correctionImage does not exists"""
 
-        if correctionImage is None:
-            return
+        # Return if the correctionImage is None or the empty string
+        if not correctionImage:
+            return None
 
         elif not os.path.exists(correctionImage):
             raise Exception("Correction image is set but not present in the "


### PR DESCRIPTION
When the gainImage was the empty string, the protocol was wrongly raising an Exception.