### PR TITLE
Bug fixing in xmipp's viewer.py: 'str' + 'int'

### DIFF
--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -158,7 +158,7 @@ class XmippViewer(Viewer):
                                                   VISIBLE: labels,
                                                   MODE: MODE_MD, RENDER: "no"})
             # For movies increase the JVM memory by 1 GB, just in case
-            moviesView.setMemory(showj.getJvmMaxMemory() + 1)
+            moviesView.setMemory(str(int(showj.getJvmMaxMemory()) + 1))
             self._views.append(moviesView)
 
         elif issubclass(cls, SetOfMicrographs):

--- a/pyworkflow/em/packages/xmipp3/viewer.py
+++ b/pyworkflow/em/packages/xmipp3/viewer.py
@@ -158,7 +158,7 @@ class XmippViewer(Viewer):
                                                   VISIBLE: labels,
                                                   MODE: MODE_MD, RENDER: "no"})
             # For movies increase the JVM memory by 1 GB, just in case
-            moviesView.setMemory(str(int(showj.getJvmMaxMemory()) + 1))
+            moviesView.setMemory(showj.getJvmMaxMemory() + 1)
             self._views.append(moviesView)
 
         elif issubclass(cls, SetOfMicrographs):

--- a/pyworkflow/em/showj.py
+++ b/pyworkflow/em/showj.py
@@ -105,7 +105,7 @@ OBJECT_ID = 'objectId'
 
 def getJvmMaxMemory():
     # Memory in GB
-    return os.environ.get("JAVA_MAX_MEMORY", 2)
+    return int(os.environ.get("JAVA_MAX_MEMORY", 2))
 
 
 class ColumnsConfig():


### PR DESCRIPTION
DataView.setMemory( ) and showj.getJvmMaxMemory() works with strings, however we want to increase the available memory to show movies in 1Gb.

I don't know if there is a cleaner way bu this fix the bug.
