### PR TITLE
Instance of a class insted of class itself in getattr

### DIFF
--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -1600,7 +1600,7 @@ class Protocol(Step):
         """
         try:
 
-            validateFunc = getattr(cls.getClassPackage().Plugin,
+            validateFunc = getattr(cls.getClassPackage().Plugin(),
                                'validateInstallation', None)
 
             return validateFunc() if validateFunc is not None else []


### PR DESCRIPTION
When I tried to add my plugin, this error raised:

unbound method validateInstallation() must be called with Plugin instance as first argument (got nothing instead)

So I did this pull request to solve this bug.