### PR TITLE
Buildbot

### DIFF
--- a/install/funcs.py
+++ b/install/funcs.py
@@ -251,9 +251,8 @@ class Environment:
         self._downloadCmd = ('wget -nv -c -O %(tar)s.part %(url)s\n'
                              'mv -v %(tar)s.part %(tar)s')
         self._tarCmd = 'tar -xzf %s'
-        pipCmdDefault = '{} {}/pip install --target={} %s==%s'.format(self.getBin('python'),
-                                                                      self.getPythonPackagesFolder(),
-                                                                      self.getPythonPackagesFolder())
+        pipCmdDefault = '{} {}/pip install %s==%s'.format(self.getBin('python'),
+                                                          self.getPythonPackagesFolder())
         self._pipCmd = kwargs.get('pipCmd', pipCmdDefault)
 
     def getLibSuffix(self):

--- a/install/funcs.py
+++ b/install/funcs.py
@@ -251,8 +251,10 @@ class Environment:
         self._downloadCmd = ('wget -nv -c -O %(tar)s.part %(url)s\n'
                              'mv -v %(tar)s.part %(tar)s')
         self._tarCmd = 'tar -xzf %s'
-        self._pipCmd = kwargs.get('pipCmd', '{} {}/pip install %s==%s'.format(self.getBin('python'),
-                                                                              self.getPythonPackagesFolder()))
+        pipCmdDefault = '{} {}/pip install --target={} %s==%s'.format(self.getBin('python'),
+                                                                      self.getPythonPackagesFolder(),
+                                                                      self.getPythonPackagesFolder())
+        self._pipCmd = kwargs.get('pipCmd', pipCmdDefault)
 
     def getLibSuffix(self):
         return self._libSuffix

--- a/install/funcs.py
+++ b/install/funcs.py
@@ -251,9 +251,8 @@ class Environment:
         self._downloadCmd = ('wget -nv -c -O %(tar)s.part %(url)s\n'
                              'mv -v %(tar)s.part %(tar)s')
         self._tarCmd = 'tar -xzf %s'
-        pipCmdDefault = '{} {}/pip install %s==%s'.format(self.getBin('python'),
-                                                          self.getPythonPackagesFolder())
-        self._pipCmd = kwargs.get('pipCmd', pipCmdDefault)
+        self._pipCmd = kwargs.get('pipCmd', '{} {}/pip install %s==%s'.format(self.getBin('python'),
+                                                                              self.getPythonPackagesFolder()))
 
     def getLibSuffix(self):
         return self._libSuffix

--- a/install/plugin_funcs.py
+++ b/install/plugin_funcs.py
@@ -110,8 +110,15 @@ class PluginInfo(object):
                       "version %s." % (self.pipName, SCIPION_VERSION))
             return False
 
-        cmd = PIP_CMD % {'installSrc': self.pluginSourceUrl or "%s==%s" %
-                                       (self.pipName, version)}
+        if self.pluginSourceUrl:
+            if os.path.exists(self.pluginSourceUrl):
+                installSrc = self.pluginSourceUrl
+            else:
+                installSrc = 'git+%s' % self.pluginSourceUrl  # path doesnt exist, we assume is git
+        else:
+            installSrc = "%s==%s" % (self.pipName, version)
+
+        cmd = PIP_CMD % {'installSrc': installSrc}
 
         pipModule = environment.addPipModule(self.pipName,
                                              target="%s*" % self.pipName.replace('-', '_'),

--- a/install/plugin_funcs.py
+++ b/install/plugin_funcs.py
@@ -113,22 +113,28 @@ class PluginInfo(object):
 
         if self.pluginSourceUrl:
             if os.path.exists(self.pluginSourceUrl):
-                installSrc = self.pluginSourceUrl
+                # install from dir in editable mode
+                installSrc = '-e %s' % self.pluginSourceUrl
+                target = "%s*" % self.pipName
             else:
-                installSrc = '--upgrade git+%s' % self.pluginSourceUrl  # path doesnt exist, we assume is git and force install
+                # path doesnt exist, we assume is git and force install
+                installSrc = '--upgrade git+%s' % self.pluginSourceUrl
+                target = "%s*" % self.pipName.replace('-', '_')
         else:
+            # install from pypi
             installSrc = "%s==%s" % (self.pipName, version)
+            target = "%s*" % self.pipName.replace('-', '_')
 
         cmd = PIP_CMD % {'installSrc': installSrc}
 
         pipModule = environment.addPipModule(self.pipName,
-                                             target="%s*" % self.pipName.replace('-', '_'),
+                                             target=target,
                                              pipCmd=cmd,
                                              ignoreDefaultDeps=True)
 
-        reloadPkgRes = self.isInstalled()  # check if we're doing a version
-                                           # change of an already installed
-                                           # plugin
+        # check if we're doing a version change of an already installed plugin
+        reloadPkgRes = self.isInstalled()
+
         environment.execute()
         if reloadPkgRes:
             # if plugin was already installed, pkg_resources has the old one

--- a/install/plugin_funcs.py
+++ b/install/plugin_funcs.py
@@ -114,7 +114,7 @@ class PluginInfo(object):
             if os.path.exists(self.pluginSourceUrl):
                 installSrc = self.pluginSourceUrl
             else:
-                installSrc = 'git+%s' % self.pluginSourceUrl  # path doesnt exist, we assume is git
+                installSrc = '--upgrade git+%s' % self.pluginSourceUrl  # path doesnt exist, we assume is git and force install
         else:
             installSrc = "%s==%s" % (self.pipName, version)
 

--- a/install/plugin_funcs.py
+++ b/install/plugin_funcs.py
@@ -11,10 +11,11 @@ from pyworkflow.utils.path import cleanPath
 from pyworkflow import LAST_VERSION, OLD_VERSIONS
 from install.funcs import Environment
 
-REPOSITORY_URL = os.environ.get('SCIPION_PLUGIN_JSON', None) or \
-                 os.environ['SCIPION_PLUGIN_REPO_URL']
+REPOSITORY_URL = (os.environ.get('SCIPION_PLUGIN_JSON', None) or
+                  os.environ['SCIPION_PLUGIN_REPO_URL'])
 PIP_BASE_URL = 'https://pypi.python.org/pypi'
-PIP_CMD = 'python {}/pip install %(installSrc)s'.format(
+PIP_CMD = '{} {}/pip install %(installSrc)s'.format(
+    Environment.getBin('python'),
     Environment.getPythonPackagesFolder())
 
 versions = list(OLD_VERSIONS) + [LAST_VERSION]

--- a/scipion
+++ b/scipion
@@ -217,14 +217,11 @@ try:
          os.environ.get('LD_LIBRARY_PATH', '')]
     )
 
-    print("ENVIRON'S PYTHONPATH: %s" % os.environ.get('PYTHONPATH', ''))
-    print("ENVIRON'S LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH', ''))
-
     PYTHONPATH_LIST = [SCIPION_HOME,
                        join(SCIPION_SOFTWARE,
                             'lib', 'python2.7', 'site-packages'),
                        XMIPP_BINDINGS,
-                       # os.environ.get('PYTHONPATH', ''),
+                       os.environ.get('PYTHONPATH', ''),
                        join(SCIPION_HOME, 'pyworkflow', 'em', 'xmipp-ghost')]  # To be able to open scipion without xmipp
 
     if 'SCIPION_NOGUI' in os.environ:

--- a/scipion
+++ b/scipion
@@ -221,7 +221,7 @@ try:
                        join(SCIPION_SOFTWARE,
                             'lib', 'python2.7', 'site-packages'),
                        XMIPP_BINDINGS,
-                       os.environ.get('PYTHONPATH', ''),
+                       os.environ.get('PYTHONPATH', '') if not os.environ.get('IGNORE_PYTHONPATH', False) else "",
                        join(SCIPION_HOME, 'pyworkflow', 'em', 'xmipp-ghost')]  # To be able to open scipion without xmipp
 
     if 'SCIPION_NOGUI' in os.environ:

--- a/scipion
+++ b/scipion
@@ -217,6 +217,8 @@ try:
          os.environ.get('LD_LIBRARY_PATH', '')]
     )
 
+    print("ENVIRON'S PYTHONPATH: %s" % os.environ.get('PYTHONPATH', ''))
+
     PYTHONPATH_LIST = [SCIPION_HOME,
                        join(SCIPION_SOFTWARE,
                             'lib', 'python2.7', 'site-packages'),

--- a/scipion
+++ b/scipion
@@ -218,12 +218,13 @@ try:
     )
 
     print("ENVIRON'S PYTHONPATH: %s" % os.environ.get('PYTHONPATH', ''))
+    print("ENVIRON'S LD_LIBRARY_PATH: %s" % os.environ.get('LD_LIBRARY_PATH', ''))
 
     PYTHONPATH_LIST = [SCIPION_HOME,
                        join(SCIPION_SOFTWARE,
                             'lib', 'python2.7', 'site-packages'),
                        XMIPP_BINDINGS,
-                       os.environ.get('PYTHONPATH', ''),
+                       # os.environ.get('PYTHONPATH', ''),
                        join(SCIPION_HOME, 'pyworkflow', 'em', 'xmipp-ghost')]  # To be able to open scipion without xmipp
 
     if 'SCIPION_NOGUI' in os.environ:

--- a/scripts/run_tests.py
+++ b/scripts/run_tests.py
@@ -73,7 +73,7 @@ class Tester():
             help='skip tests that contains these words')
         add('--log', default=None, nargs='?',
             help="Generate logs files with the output of each test.")
-        add('--mode', default='classes', choices=['modules', 'classes', 'all'],
+        add('--mode', default='classes', choices=['modules', 'classes', 'onlyclasses', 'all'],
             help='how much detail to give in show mode')
         add('tests', metavar='TEST', nargs='*',
             help='test case from string identifier (module, class or callable)')
@@ -146,7 +146,7 @@ class Tester():
         """ Show the list of tests available """
         mode = self.mode
     
-        assert mode in ['modules', 'classes', 'all'], 'Unknown mode %s' % mode
+        assert mode in ['modules', 'classes', 'onlyclasses', 'all'], 'Unknown mode %s' % mode
     
         # First flatten the list of tests.
         # testsFlat = list(iter(self.__iterTests(tests)))
@@ -181,10 +181,10 @@ class Tester():
 
                 if testModuleName != lastModule:
                     lastModule = testModuleName
-                    newItemCallback(MODULE, "%s"
-                                    % (testModuleName))
+                    if mode != 'onlyclasses':
+                        newItemCallback(MODULE, "%s" % testModuleName)
 
-                if mode in ['classes', 'all'] and className != lastClass:
+                if mode in ['classes', 'onlyclasses', 'all'] and className != lastClass:
                     lastClass = className
                     newItemCallback(CLASS, "%s.%s"
                                     % (testModuleName, className))


### PR DESCRIPTION
Summary of changes:
- Support environment variable IGNORE_PYTHONPATH so that external pythonpath doesn't mess with scipion python operations
- Add pip install in editable mode if installing a plugin from a directory
- Add "only classes" mode for test --show, which will print only the individual tests (without their module name).