### PR TITLE
modeling_1 incorporate sequence class

### DIFF
--- a/config/templates/protocols.template
+++ b/config/templates/protocols.template
@@ -10,14 +10,15 @@ Protocols SPA = [
 		{"tag": "protocol", "value": "ProtImportParticles",   "text": "import particles"},
 		{"tag": "protocol", "value": "ProtImportVolumes",     "text": "import volumes"},
 		{"tag": "section", "text": "more", "openItem": "False", "children": [
-			{"tag": "protocol", "value": "ProtImportCoordinates",   "text": "import coordinates"},
-			{"tag": "protocol", "value": "ProtImportCTF",   "text": "import ctfs"},
-			{"tag": "protocol", "value": "ProtImportPdb",         "text": "import PDB"},
-			{"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
-			{"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},
-			{"tag": "protocol", "value": "ProtImportMicrographsTiltPairs", "text": "import micrograph pairs"},
-			{"tag": "protocol", "value": "ProtEmxExport",         "text": "export to EMX"},
-			{"tag": "protocol", "value": "ProtExportEMDB",         "text": "export to EMDB"}
+		{"tag": "protocol", "value": "ProtImportCoordinates",   "text": "import coordinates"},
+		{"tag": "protocol", "value": "ProtImportCTF",   "text": "import ctfs"},
+		{"tag": "protocol", "value": "ProtImportPdb",   "text": "import atomic structure"},
+		{"tag": "protocol", "value": "ProtImportSequence",   "text": "import sequence"},
+		{"tag": "protocol", "value": "ProtImportAverages",    "text": "import averages"},
+		{"tag": "protocol", "value": "ProtImportMask",        "text": "import masks"},
+		{"tag": "protocol", "value": "ProtImportMicrographsTiltPairs", "text": "import micrograph pairs"},
+		{"tag": "protocol", "value": "ProtEmxExport",         "text": "export to EMX"},
+		{"tag": "protocol", "value": "ProtExportEMDB",         "text": "export to EMDB"}
 		]}
 	]},
 	{"tag": "section", "text": "Movies", "openItem": "False", "children": [

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -776,6 +776,68 @@ class EMFile(EMObject):
         """ Use the _objValue attribute to store filename. """
         self._filename.set(filename)
 
+class Sequence(EMObject):
+    """Class containing a sequence of aminoacids/nucleotides
+       Attribute names follow the biopython default ones
+    """
+
+    def __init__(self, name=None, sequence=None,
+                 alphabet=None, isAminoacids=True, id=None, description=None,
+                 **kwargs):
+        EMObject.__init__(self, **kwargs)
+        # sequence Id, usually from a database. E.g: P12345
+        self._id = String(id)
+        # Descriptive alias provided by the user. E.g: CicloxigenasaB
+        self._name = String(name)
+        # Id this a aminoacid or nucleotide sequence
+        self._isAminoacids = Boolean(isAminoacids)
+        # So far we just use _description when creating 'fasta' sequence files
+        self._description = String(description)
+        # sequence stores a string of residues (one character per residue)
+        self._sequence = String(sequence)
+        # alphabet is used to describe de convention followed to
+        # store the _sequence. We follow biopython criteria
+        self._alphabet = Integer(alphabet)
+
+    def getId(self):
+        return self._id.get()
+
+    def setId(self, id):
+        self._id.set(id)
+
+
+    # Note that the natural name for the next two functions are
+    # getName and  setName but
+    # setName is defined in Object for another purpose
+    def getSeqName(self):
+        return self._name.get()
+
+    def setSeqName(self, name):
+        self._name.set(name)
+
+    def getSequence(self):
+        return self._sequence.get()
+
+    def setSequence(self, sequence):
+        self._sequence.set(sequence)
+
+    def getDescription(self):
+        return self._description.get()
+
+    def setDescription(self, description):
+        self._description.set(description)
+
+    # Note: Alphabet is set when the sequence object is created
+    # after that it makes no sense to change the alphabet
+    def getAlphabet(self):
+        return self._alphabet.get()
+
+    def getIsAminoacids(self):
+        return self._isAminoacids
+
+    def __str__(self):
+         return self.getSeqName()
+
 
 class PdbFile(EMFile):
     """Represents an PDB file. """
@@ -1258,6 +1320,10 @@ class SetOfDefocusGroup(EMSet):
 class SetOfPDBs(EMSet):
     """ Set containing PDB items. """
     ITEM_TYPE = PdbFile
+
+class SetOfSequences(EMSet):
+    """Set containing Sequence items."""
+    ITEM_TYPE = Sequence
 
 
 class Coordinate(EMObject):
@@ -2091,5 +2157,5 @@ class FSC(EMObject):
 
 
 class SetOfFSCs(EMSet):
-    """Represents a set of Volumes"""
+    """Represents a set of FSCs"""
     ITEM_TYPE = FSC

--- a/pyworkflow/em/handler_atom_struct.py
+++ b/pyworkflow/em/handler_atom_struct.py
@@ -1,0 +1,451 @@
+# **************************************************************************
+# *
+# * Authors:     Roberto Marabini (roberto@cnb.csic.es)
+# *              Marta Martinez (mmmtnez@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+#
+# cif to pdb convertion is based on  cif2pdb.py by Spencer Bliven
+# <spencer.bliven@gmail.com>
+#
+# see http://biopython.org/DIST/docs/tutorial/Tutorial.html for a description
+# on the object "structure" and other Bio.xxxx modules
+
+import os
+import numpy
+
+from Bio.PDB.MMCIFParser import MMCIFParser
+from Bio.PDB.PDBParser import PDBParser
+from Bio.PDB import PDBIO, MMCIFIO
+from Bio.PDB.MMCIF2Dict import MMCIF2Dict
+from Bio.PDB import Entity
+from Bio.PDB import PDBList
+from Bio.PDB.Polypeptide import PPBuilder
+from pyworkflow.em.transformations import rotation_from_matrix, \
+    translation_from_matrix
+from pyworkflow.em.handler_sequence import SequenceHandler
+from collections import OrderedDict
+from Bio.PDB.Polypeptide import is_aa
+from Bio.PDB.Polypeptide import three_to_one
+from Bio.Seq import Seq
+from Bio.Alphabet import IUPAC
+
+class OutOfChainsError(Exception):
+    pass
+
+class AtomicStructHandler():
+    """ Class that contain utilities to handle pdb/cif files"""
+    PDB = 0
+    CIF = 1
+
+    def __init__(self, fileName=None, permissive=1):
+        # The PERMISSIVE flag indicates that a number of common problems
+        # associated with PDB files will be ignored
+        self.permissive = permissive
+        self.pdbParser = None
+        self.cifParser = None
+        self.ioPDB = None
+        self.ioCIF = None
+        self.structure = None
+        self._readDone = False
+        if fileName is not None:
+            self.read(fileName)
+
+    def readFromPDBDatabase(self, pdbID, dir=None, type='mmCif'):
+        """
+        Retrieve structure from PDB
+        :param pdbID:
+        :param dir: save structure in this directory
+        :param type:  mmCif or pdb
+        :return:
+        """
+        if dir is None:
+            dir = os.getcwd()
+        pdbl = PDBList()
+        fileName = pdbl.retrieve_pdb_file(pdbID, pdir=dir, file_format=type)
+        self.read(fileName)
+        return fileName
+
+    def getStructure(self):
+        """return strcture information, model, chain,
+           residues, atoms..."""
+        return self.structure
+
+    def read(self, fileName):
+        """ Read and parse file."""
+        # biopython assigns an ID to any read structure
+        structure_id = os.path.basename(fileName)
+        structure_id = structure_id[:4] if len(structure_id) > 4 else "1xxx"
+
+        if fileName.endswith(".pdb") or fileName.endswith(".ent"):
+            if self.pdbParser is None:
+                self.pdbParser = PDBParser(PERMISSIVE=self.permissive)
+            parser = self.pdbParser
+            self.type = self.PDB
+        else:
+            if self.cifParser is None:
+                self.cifParser = MMCIFParser()
+            parser = self.cifParser
+            self.type = self.CIF
+
+        self.structure = parser.get_structure(structure_id, fileName)
+        self._readDone = True
+
+    def checkRead(self):
+        if self._readDone:
+            return True
+        else:
+            print "you must read the pdb file first"
+            exit(0)
+
+    def getModelsChains(self):
+        """
+        return a dic of all models and respective chains (chainID and
+        length of residues) from a pdb file
+        """
+        self.checkRead()
+        models = OrderedDict()
+
+        for model in self.structure:
+            chainDic = OrderedDict()
+            for chain in model:
+                if len(chain.get_unpacked_list()[0].resname) == 1: # RNA
+                    seq = list()
+                    for residue in chain:
+                        if residue.get_resname() in ['A', 'C', 'G', 'U']:
+                            seq.append(residue.get_resname())
+                        else:
+                            seq.append("X")
+                elif len(chain.get_unpacked_list()[0].resname) == 2: # DNA
+                    seq = list()
+                    for residue in chain:
+                        if residue.get_resname()[1] in ['A', 'C', 'G', 'T']:
+                            seq.append(residue.get_resname()[1])
+                        else:
+                            seq.append("X")
+                elif len(chain.get_unpacked_list()[0].resname) == 3: # Protein
+                    seq = list()
+                    for residue in chain:
+                        if is_aa(residue.get_resname(), standard=True):
+                            seq.append(three_to_one(residue.get_resname()))
+                        else:
+                            seq.append("X")
+                while seq[-1] == "X":
+                    del seq[-1]
+                while seq[0] == "X":
+                    del seq[0]
+                chainDic[chain.id] = len(seq)
+            models[model.id] = chainDic
+
+        return models
+
+    def getSequenceFromChain(self, modelID, chainID):
+        self.checkRead()
+        seq = list()
+        for model in self.structure:
+            if str(model.id) == modelID:
+                for chain in model:
+                    if str(chain.id) == chainID:
+                        if len(chain.get_unpacked_list()[0].resname) == 1:
+                            print "Your sequence is a nucleotide sequence (" \
+                                  "RNA)\n"
+                            # alphabet = IUPAC.IUPACAmbiguousRNA._upper()
+                            for residue in chain:
+                                ## Check if the residue belongs to the
+                                ## standard RNA and add those residues to the
+                                ## seq
+                                if residue.get_resname() in ['A', 'C',
+                                                                'G', 'U']:
+                                    seq.append(residue.get_resname())
+                                else:
+                                    seq.append("X")
+                        elif len(chain.get_unpacked_list()[0].resname) == 2:
+                            print "Your sequence is a nucleotide sequence (" \
+                                  "DNA)\n"
+                            # alphabet = IUPAC.ExtendedIUPACDNA._upper()
+                            for residue in chain:
+                                ## Check if the residue belongs to the
+                                ## standard DNA and add those residues to the
+                                ## seq
+                                if residue.get_resname()[1] in ['A', 'C',
+                                                                'G', 'T']:
+                                    seq.append(residue.get_resname()[1])
+                                else:
+                                    seq.append("X")
+                        elif len(chain.get_unpacked_list()[0].resname) == 3:
+                            print "Your sequence is an aminoacid sequence"
+                            #alphabet = IUPAC.ExtendedIUPACProtein._upper()
+                            for residue in chain:
+                                ## The test below checks if the amino acid
+                                ## is one of the 20 standard amino acids
+                                ## Some proteins have "UNK" or "XXX", or other symbols
+                                ## for missing or unknown residues
+                                if is_aa(residue.get_resname(), standard=True):
+                                    seq.append(three_to_one(residue.get_resname()))
+                                else:
+                                    seq.append("X")
+                        while seq[-1] == "X":
+                            del seq[-1]
+                        while seq[0] == "X":
+                            del seq[0]
+                        # return Seq(str(''.join(seq)), alphabet=alphabet)
+                        return Seq(str(''.join(seq)))
+
+    def getFullID(self, model_id='0', chain_id=None):
+        """
+        assign a label to a sequence obtained from a PDB file
+        :parameter
+        model_id
+        chain_id
+        :return: string with label
+        """
+        self.checkRead()  # cehck we have read the structure
+        label = "%s" % self.structure.get_id()  # PDB_ID
+        # check how many model are in sequence if > 1 add to id
+        models = self.getModelsChains()
+        if len(models) > 1:
+            label = label + "__%s" % str(model_id)
+        # if chain_id is None do not add it to te name
+        if chain_id is not None:
+            label = label + "_%s" % str(chain_id)
+        return label
+
+
+    def readLowLevel(self, fileName):
+        """ Return a dictionary with all mmcif fields. you should parse them
+            Example: get the list of the y coordinates of all atoms
+              dict = readLowLevel("kk.pdb")
+              y_list = dict['_atom_site.Cartn_y']
+        """
+
+        if fileName.endswith(".pdb"):
+            print ("Low level access to PDB is not implemented")
+        else:
+            dict = MMCIF2Dict(fileName)
+        return dict
+
+    def _write(self, fileName):
+        """ Do not use this function use toPDB or toCIF, they take care of some
+        compatibiity issues"""
+        if fileName.endswith(".pdb") or fileName.endswith(".ent"):
+            if self.ioPDB is None:
+                self.ioPDB = PDBIO()
+            io = self.ioPDB
+        else:
+            if self.ioCIF is None:
+                self.ioCIF = MMCIFIO()
+            io = self.ioCIF
+        io.set_structure(self.structure)
+        io.save(fileName)
+
+    def _writeLowLevel(self, fileName, dict):
+        """ write a dictionary as cif file
+        """
+
+        if fileName.endswith(".pdb"):
+            print ("Low level access to PDB is not implemented")
+        else:
+            if self.ioCIF is None:
+                self.ioCIF = MMCIFIO()
+            io = self.ioCIF
+        io.set_dict(dict)
+        io.save(fileName)
+
+    def _intToChain(self, i, base=62):
+        """
+        int_to_chain(int,int) -> str
+        Converts a positive integer to a chain ID. Chain IDs include uppercase
+        characters, numbers, and optionally lowercase letters.
+        i = a positive integer to convert
+        base = the alphabet size to include. Typically 36 or 62.
+        """
+        if i < 0:
+            raise ValueError("positive integers only")
+        if base < 0 or 62 < base:
+            raise ValueError("Invalid base")
+
+        quot = int(i) // base
+        rem = i % base
+        if rem < 26:
+            letter = chr(ord("A") + rem)
+        elif rem < 36:
+            letter = str(rem - 26)
+        else:
+            letter = chr(ord("a") + rem - 36)
+        if quot == 0:
+            return letter
+        else:
+            return self._intToChain(quot - 1, base) + letter
+
+    def renameChains(self, structure):
+        """Renames chains to be one-letter chains
+
+        Existing one-letter chains will be kept.
+        Multi-letter chains will be truncated
+        or renamed to the next available letter of the alphabet.
+
+        If more than 62 chains are present in the structure,
+        raises an OutOfChainsError
+
+        Returns a map between new and old chain IDs, as well as modifying
+        the input structure
+
+        """
+        next_chain = 0  #
+        # single-letters stay the same
+        chainmap = {c.id: c.id
+                    for c in structure.get_chains() if len(c.id) == 1}
+        for o in structure.get_chains():
+            if len(o.id) != 1:
+                if o.id[0] not in chainmap:
+                    chainmap[o.id[0]] = o.id
+                    o.id = o.id[0]
+                else:
+                    c = self._intToChain(next_chain)
+                    while c in chainmap:
+                        next_chain += 1
+                        c = self._intToChain(next_chain)
+                        if next_chain >= 62:
+                            raise OutOfChainsError()
+                    chainmap[c] = o.id
+                    o.id = c
+        return chainmap
+
+    def write(self, fileName):
+        if fileName.endswith(".pdb") or fileName.endswith(".ent"):
+            self.writeAsPdb(fileName)
+        else:
+            self.writeAsCif(fileName)
+
+    def writeAsPdb(self, pdbFile):
+        """ Save structure as PDB. Be aware that this is not a lossless convertion
+        Returns False is conversion is not possible. True otherwise
+        """
+        # check input is not PDB
+        if self.type == self.PDB:
+            pass
+        else:
+            # rename long chains
+            try:
+                chainmap = self.renameChains(self.structure)
+            except OutOfChainsError:
+                print("Too many chains to represent in PDB format")
+                return False
+
+            for new, old in chainmap.items():
+                if new != old:
+                    print("Renaming chain {0} to {1}".format(old, new))
+
+        self._write(pdbFile)
+
+        return True
+
+    def writeAsCif(self, cifFile):
+        """ Save structure as CIF.
+            Be aware that this is not a lossless convertion
+        """
+        self._write(cifFile)
+
+    def centerOfMass(self, geometric=False):
+        """
+        Returns gravitic [default] or geometric center of mass of an Entity
+        (anything with a get_atoms function in biopython.
+        Geometric assumes all masses are equal (geometric=True)
+        """
+        entity = self.structure
+        # Structure, Model, Chain, Residue
+        if isinstance(entity, Entity.Entity):
+            atom_list = entity.get_atoms()
+        # List of Atoms
+        elif hasattr(entity, '__iter__') and \
+                [x for x in entity if x.level == 'A']:
+            atom_list = entity
+        else:  # Some other weirdo object
+            raise ValueError("Center of Mass can only be calculated "
+                             "from the following objects:\n"
+                             "Structure, Model, Chain, Residue, "
+                             "list of Atoms.")
+
+        masses = []
+        positions = [[], [], []]
+
+        for atom in atom_list:
+            masses.append(atom.mass)
+
+            for i, coord in enumerate(atom.coord.tolist()):
+                positions[i].append(coord)
+
+        # If there is a single atom with undefined mass complain loudly.
+        if 'ukn' in set(masses) and not geometric:
+            raise ValueError("Some Atoms don't have an element assigned.\n"
+                             "Try adding them manually or calculate the "
+                             "geometrical center of mass instead.")
+
+        if geometric:
+            return [sum(coord_list) / len(masses) for coord_list in positions]
+        else:
+            w_pos = [[], [], []]
+            for atom_index, atom_mass in enumerate(masses):
+                w_pos[0].append(positions[0][atom_index] * atom_mass)
+                w_pos[1].append(positions[1][atom_index] * atom_mass)
+                w_pos[2].append(positions[2][atom_index] * atom_mass)
+
+            return [sum(coord_list) / sum(masses) for coord_list in w_pos]
+
+    def transform(self, transformation_matrix, sampling=1.):
+        """ Geometrical transformation of a PDB structure
+
+        :param entity: PDB biopython structure
+        :param transformation_matrix -> 4x4 scipion matrix
+        :paramsampling: scipion transform matrix is applied to voxels so
+              length must be multiplied by samplingRate
+
+        internal variables:
+             rotation matrix -> numpy.array(
+                      [[ 0.5, -0.809017,  0.309017],
+                       [ 0.809017,  0.30917,  -0.5     ],
+                       [ 0.309017,  0.5,       0.809017]])
+             translation: translation vector -> numpy.array([1., 0., 0.], 'd')
+        :return: no return, new data overwrites entity
+        """
+        # bioPhython and Scipion conventions do not match
+        rotation_matrix = numpy.transpose(transformation_matrix[:3, :3])
+        # from geometry get euler angles and recreate matrix
+        translation = translation_from_matrix(transformation_matrix)
+        translation = [x * sampling for x in translation]
+        self.structure.transform(rotation_matrix, translation)
+
+def cifToPdb(fnCif,fnPdb):
+    h = AtomicStructHandler()
+    h.read(fnCif)
+    h.writeAsPdb(fnPdb)
+
+#rethink
+# def getNumberModelsChains(parsed_structure):
+#     countModels = 0
+#     for model in parsed_structure:
+#         countModels += 1
+#         countChains = 0
+#         for chain in model:
+#             countChains += 1
+#     return countModels, countChains

--- a/pyworkflow/em/handler_sequence.py
+++ b/pyworkflow/em/handler_sequence.py
@@ -1,0 +1,223 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     Marta Martinez (mmmtnez@cnb.csic.es)
+# *              Roberto Marabini (roberto@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+
+# sequence related stuff
+SEQ_TYPE=['aminoacids', 'nucleotides']
+SEQ_TYPE_AMINOACIDS = 0
+SEQ_TYPE_NUCLEOTIDES = 1
+IUPAC_PROTEIN_ALPHABET = ['Extended Protein', 'Protein']
+EXTENDED_PROTEIN_ALPHABET = 0
+PROTEIN_ALPHABET = 1
+IUPAC_NUCLEOTIDE_ALPHABET = ['Ambiguous DNA', 'Unambiguous DNA',
+                             'Extended DNA', 'Ambiguous RNA',
+                             'Unambiguous RNA']
+EXTENDED_DNA_ALPHABET = 0
+AMBIGOUS_DNA_ALPHABET = 1
+UNAMBIGOUS_DNA_ALPHABET = 2
+AMBIGOUS_RNA_ALPHABET = 3
+UNAMBIGOUS_RNA_ALPHABET = 4
+
+
+from Bio.Seq import Seq
+from Bio.Alphabet import IUPAC
+from Bio import Entrez, SeqIO
+import urllib, urllib2, sys
+from Bio.SeqRecord import SeqRecord
+import os
+from Bio.Align.Applications import ClustalOmegaCommandline, MuscleCommandline
+from Bio import pairwise2
+
+
+class SequenceHandler():
+    def __init__(self, sequence=None,
+                 iUPACAlphabet=0,
+                 isAminoacid=True):
+
+        self.isAminoacid = isAminoacid
+        self.alphabet = indexToAlphabet(isAminoacid, iUPACAlphabet)
+
+        if sequence is not None:
+            #sequence = cleanSequence(self.alphabet, sequence)
+            self._sequence = Seq(sequence, alphabet=self.alphabet)
+        else:
+            self._sequence = None
+            # type(self._sequence):  <class 'Bio.Seq.Seq'>
+
+    def saveFile(self, fileName, seqID, sequence=None, name=None,
+                 seqDescription=None, type="fasta"):
+        if sequence is not None:
+            self._sequence = sequence
+        record = SeqRecord(self._sequence, id=seqID, name=name,
+                           description=seqDescription)
+        # type(record): < class 'Bio.SeqRecord.SeqRecord'>
+        with open(fileName, "w") as output_handle:
+            SeqIO.write(record, output_handle, type)
+
+    def downloadSeqFromFile(self, fileName, type="fasta"):
+        record = next(SeqIO.parse(fileName, type))
+        return record
+
+    def downloadSeqFromDatabase(self, seqID):
+        # see http://biopython.org/DIST/docs/api/Bio.SeqIO-module.html
+        # for format/databases
+        print "Connecting to dabase..."
+        seqID = str(seqID)
+        sys.stdout.flush()
+        counter=1
+        retries = 5
+        record = None
+        error = ""
+        while counter <= retries:  # retry up to 5 times if server busy
+            try:
+                if self.isAminoacid:
+                    dataBase = 'UnitProt'
+                    url = "http://www.uniprot.org/uniprot/%s.xml"
+                    format = "uniprot-xml"
+                    handle = urllib2.urlopen(url % seqID)
+                    print "URL", url % seqID
+                else:
+                    dataBase = 'GeneBank'
+                    Entrez.email = "adam.richards@stat.duke.edu"
+                    format = "fasta"
+                    handle = Entrez.efetch(db="nucleotide", id=seqID,
+                                           rettype=format, retmode="text")
+
+                record = SeqIO.read(handle, format)
+                print "record: ", record
+                break
+            except urllib2.HTTPError, e:
+                error = "%s is a wrong sequence ID" % seqID
+                print e.code
+            except urllib2.URLError, e:
+                error = "Cannot connet to %s" % dataBase
+                print e.args
+            except Exception as ex:
+                template = "An exception of type {0} occurred. Arguments:\n{1!r}"
+                message = template.format(type(ex).__name__, ex.args)
+                error = message
+            if counter == retries:
+                break
+            counter += 1
+        return record, error
+
+    def alignSeq(self, referenceSeq):
+        if self._sequence is not None:
+            alignments = pairwise2.align.globalds(self._sequence.seq,
+                                                  referenceSeq.seq)
+            return alignments
+        else:
+            print "read the sequence first"
+            exit(0)
+
+def cleanSequenceScipion(isAminoacid, iUPACAlphabet, sequence):
+    return cleanSequence(indexToAlphabet(isAminoacid, iUPACAlphabet), sequence)
+
+def cleanSequence(alphabet, sequence):
+    str_list = []
+    for item in sequence.upper():
+        if item in alphabet.letters:
+            str_list.append(item)
+    value =  ''.join(str_list)
+    return ''.join(str_list)
+
+def indexToAlphabet(isAminoacid, iUPACAlphabet):
+    if isAminoacid:
+        if iUPACAlphabet == EXTENDED_PROTEIN_ALPHABET:
+            alphabet = IUPAC.ExtendedIUPACProtein
+        else:
+            alphabet = IUPAC.IUPACProtein
+    else:
+        if iUPACAlphabet == EXTENDED_DNA_ALPHABET:
+            alphabet = IUPAC.ExtendedIUPACDNA
+        elif iUPACAlphabet == AMBIGOUS_DNA_ALPHABET:
+            alphabet = IUPAC.IUPACAmbiguousDNA
+        elif iUPACAlphabet == UNAMBIGOUS_DNA_ALPHABET:
+            alphabet = IUPAC.IUPACUnambiguousDNA
+        elif iUPACAlphabet == AMBIGOUS_RNA_ALPHABET:
+            alphabet = IUPAC.IUPACAmbiguousRNA
+        else:
+            alphabet = IUPAC.IUPACUnambiguousRNA
+    return alphabet
+
+def alphabetToIndex(isAminoacid, alphabet):
+    if isAminoacid:
+        if type(alphabet) is type(IUPAC.ExtendedIUPACProtein):
+            return EXTENDED_PROTEIN_ALPHABET
+        else:
+            return PROTEIN_ALPHABET
+    else:
+        if type(alphabet) is type(IUPAC.ExtendedIUPACDNA):
+            return EXTENDED_DNA_ALPHABET
+        elif type(alphabet) is type(IUPAC.IUPACAmbiguousDNA):
+            return AMBIGOUS_DNA_ALPHABET
+        elif type(alphabet) is type(IUPAC.IUPACUnambiguousDNA):
+            return UNAMBIGOUS_DNA_ALPHABET
+        elif type(alphabet) is type(IUPAC.IUPACAmbiguousRNA):
+            return AMBIGOUS_RNA_ALPHABET
+        else:
+            return UNAMBIGOUS_RNA_ALPHABET
+
+def saveFileSequencesToAlign(SeqDic, inFile, type="fasta"):
+    # Write my sequences to a fasta file
+    with open(inFile, "w") as output_handle:
+        for index, seq in SeqDic.iteritems():
+            record = SeqRecord(seq, id=str(index),
+                           name="", description="")
+            SeqIO.write(record, output_handle, type)
+
+def alignClustalSequences(inFile, outFile):
+    # Alignment of sequences with Clustal Omega program
+    clustalomega_cline = ClustalOmegaCommandline(
+            infile=inFile,
+            outfile=outFile,
+            verbose=True, auto=True)
+    return clustalomega_cline
+
+def alignMuscleSequences(inFile, outFile):
+    # Alignment of sequences with Muscle program
+    muscle_cline = MuscleCommandline(input=inFile, out=outFile)
+    return muscle_cline
+
+def alignBioPairwise2Sequences(structureSequenceId, structureSequence,
+              userSequenceId, userSequence,
+              outFileName):
+    "aligns two sequences and saves them to disk using fasta format"
+    # see alignment_function for globalms parameters
+    alignments = pairwise2.align.globalms(structureSequence,
+                                           userSequence,  3, -1, -3, -2)
+    align1, align2, score, begin, end = alignments[0]
+    with open(outFileName, "w") as handle:
+        handle.write(">%s\n%s\n>%s\n%s\n" % (structureSequenceId,
+                                             align1,
+                                             userSequenceId,
+                                             align2))
+
+
+
+

--- a/pyworkflow/em/protocol/protocol_import/__init__.py
+++ b/pyworkflow/em/protocol/protocol_import/__init__.py
@@ -37,5 +37,6 @@ from masks import ProtImportMask
 from micrographs import ProtImportMicrographs, ProtImportMovies
 from particles import ProtImportParticles, ProtImportAverages
 from volumes import ProtImportVolumes, ProtImportPdb
+from sequence import ProtImportSequence
 #from viewer import viewerProtImportVolumes, viewerProtImportStructure
 from viewer import viewerProtImportVolumes

--- a/pyworkflow/em/protocol/protocol_import/sequence.py
+++ b/pyworkflow/em/protocol/protocol_import/sequence.py
@@ -1,0 +1,503 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     Marta Martinez (mmmtnez@cnb.csic.es)
+# *              Roberto Marabini (roberto@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from os.path import exists
+import os
+import pyworkflow.protocol.params as params
+from base import ProtImportFiles
+from pyworkflow.em import Sequence
+from pyworkflow.em.handler_sequence import SEQ_TYPE_AMINOACIDS,\
+    SEQ_TYPE_NUCLEOTIDES, IUPAC_PROTEIN_ALPHABET, SEQ_TYPE, \
+    EXTENDED_PROTEIN_ALPHABET, IUPAC_NUCLEOTIDE_ALPHABET, \
+    EXTENDED_DNA_ALPHABET, SequenceHandler, cleanSequenceScipion, \
+    alphabetToIndex
+from pyworkflow.em.handler_atom_struct import AtomicStructHandler
+from tkMessageBox import showerror
+
+def errorWindow(tkParent, msg):
+    try:
+        showerror("Error",  # bar title
+                  msg,  # message
+                  parent=tkParent)
+    except:
+        print("Error:", msg)
+
+
+class ProtImportSequence(ProtImportFiles):
+    """ Protocol to import an aminoacid/nucleotide sequence file to the
+    project"""
+    _label = 'import sequence'
+    #SEQUENCEFILENAME = '_sequence.fasta'
+    IMPORT_FROM_PLAIN_TEXT = 0
+    IMPORT_FROM_STRUCTURE = 1
+    IMPORT_FROM_FILES = 2
+    IMPORT_FROM_UNIPROT = 3
+    IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT = 0
+    IMPORT_FROM_NUCLEOTIDE_STRUCTURE = 1
+    IMPORT_FROM_NUCLEOTIDE_FILES = 2
+    IMPORT_FROM_GENEBANK = 3
+    IMPORT_STRUCTURE_FROM_ID = 0
+    IMPORT_STRUCTURE_FROM_FILES = 1
+
+    url = "http://www.uniprot.org/uniprot/"
+
+    def __init__(self, **args):
+        ProtImportFiles.__init__(self, **args)
+
+    def _defineParams(self, form):
+
+        form.addSection(label='Input')
+        form.addParam('inputSequenceID', params.StringParam,
+                      label="Sequence ID", allowsNull=True,
+                      help="Write a sequence ID. Otherwise, if the "
+                           "sequence derives from GeneBank/UniProt/PDB "
+                           "databases, the respective database ID will be "
+                           "selected as starting sequence ID; examples: if "
+                           "you select GeneBank accession AJ520101, SCIPION "
+                           "will assign AJ520101 as sequence ID; if "
+                           "you select UniProt accession P12345, SCIPION will "
+                           "assign P12345 as sequence ID; if you "
+                           "select atomic structure 3lqd.cif, chain B, "
+                           "SCIPION will assign 3lqd_B as sequence ID. In "
+                           "the rest of cases, the Sequence name "
+                           "will be selected as starting Sequence ID.")
+        form.addParam('inputSequenceName', params.StringParam, important=True,
+                      label="Sequence name", allowsNull=False,
+                      help="Write a sequence name.")
+        form.addParam('inputSequenceDescription', params.StringParam,
+                      label="Sequence description",
+                      allowsNull=True,
+                      help="Write a description for your sequence. Otherwise, "
+                           "if the "
+                           "sequence derives from GeneBank/UniProt/PDB "
+                           "databases, the respective database description "
+                           "will be "
+                           "selected as starting sequence description. In "
+                           "the rest of cases, no sequence description will "
+                           "be added.")
+        form.addParam('inputSequence', params.EnumParam,
+                      pointerClass='Sequence',
+                      choices=SEQ_TYPE,
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      label="Import sequence of ",
+                      default=SEQ_TYPE_AMINOACIDS,
+                      help='Select the type of sequence to import.')
+        form.addParam('inputProteinSequence', params.EnumParam,
+                      choices=['plain text', 'atomic structure', 'file',
+                               'UniProt ID'],
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      condition='inputSequence == %d' % SEQ_TYPE_AMINOACIDS,
+                      label="From ",
+                      default=self.IMPORT_FROM_PLAIN_TEXT,
+                      help='Select one of the four options: write the '
+                           'aminoacid sequence or import it '
+                           'from a previously loaded atomic structure, a local '
+                           'file or an online server.')
+        form.addParam('proteinIUPACalphabet', params.EnumParam,
+                      choices=IUPAC_PROTEIN_ALPHABET,
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      condition='inputSequence == %d and '
+                                'inputProteinSequence == %d' %
+                                (SEQ_TYPE_AMINOACIDS,
+                                 self.IMPORT_FROM_PLAIN_TEXT),
+                      label="IUPAC Protein alphabet: ",
+                      default=EXTENDED_PROTEIN_ALPHABET,
+                      help='Your raw sequence will be cleaned according '
+                           'a certain alphabet, i.e., only the letters '
+                           'contained in the alphabet will be maintained in '
+                           'the sequence. Select thus the type of protein '
+                           'alphabet in order to accomplish the '
+                           'cleaning:\n\nProtein alphabet: IUPAC protein '
+                           'alphabet of the 20 standard amino acids; uppercase'
+                           ' and single letter: *ACDEFGHIKLMNPQRSTVWY*.\n\n'
+                           'Extended Protein alphabet: Extended uppercase '
+                           'IUPAC '
+                           'protein single letter alphabet including X etc.\n'
+                           'In addition to the standard 20 single letter '
+                           'protein codes, this includes:\n*B = Asx*; '
+                           'Aspartic acid (R) or Asparagine (N)\n*X = Xxx*"; '
+                           'Unknown or other amino acid\n*Z = Glx*; Glutamic '
+                           'acid (E) or Glutamine (Q)\n*J = Xle*; Leucine ('
+                           'L) or Isoleucine (I), used in mass-spec (NMR)\n'
+                           '*U = Sec*; Selenocysteine\n*O = Pyl*; '
+                           'Pyrrolysine\nThis alphabet is not intended to be '
+                           'used with X for Selenocysteine (an ad-hoc standard'
+                           ' prior to the IUPAC adoption of U instead).\n')
+        form.addParam('uniProtSequence', params.StringParam,
+                      condition='inputSequence == %d and '
+                                'inputProteinSequence == %d' %
+                                (SEQ_TYPE_AMINOACIDS,
+                                 self.IMPORT_FROM_UNIPROT),
+                      label="UniProt name/ID ", allowsNull=True,
+                      help='Write a UniProt ID (six or ten alphanumeric '
+                           'characters; examples: A2BC19, P12345, '
+                           'A0A022YWF9, DGAL_ECOLI).\n You can convert other '
+                           'database identifiers to UniProt accession codes '
+                           'by using the "ID Mapping" tab on '
+                           'https://www.uniprot.org/')
+        form.addParam('inputNucleotideSequence', params.EnumParam,
+                      choices=['plain text', 'atomic structure', 'file',
+                               'GeneBank'],
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      condition='inputSequence == %d' % SEQ_TYPE_NUCLEOTIDES,
+                      label="From ",
+                      default=self.IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT,
+                      help='Select one of the four options: write the '
+                           'nucleic acid sequence or import it '
+                           'from a local file or an online server.')
+        form.addParam('nucleotideIUPACalphabet', params.EnumParam,
+                      choices=IUPAC_NUCLEOTIDE_ALPHABET,
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      condition='inputSequence == %d and '
+                                'inputNucleotideSequence == %d' %
+                                (SEQ_TYPE_NUCLEOTIDES,
+                                 self.IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT),
+                      label="IUPAC Nucleic acid alphabet: ",
+                      default=EXTENDED_DNA_ALPHABET,
+                      help='Your raw sequence will be cleaned according '
+                           'a certain alphabet, i.e., only the letters '
+                           'contained in the alphabet will be maintained in '
+                           'the sequence. Select thus the type of nucleic '
+                           'acid alphabet in order to accomplish the '
+                           'cleaning:\n\n Ambiguous DNA alphabet: Uppercase '
+                           'IUPAC ambiguous DNA: *GATCRYWSMKHBVDN*.\n\n'
+                           'Unambiguous DNA alphabet: Uppercase IUPAC unambiguous DNA '
+                           '(letters *GATC* only).\n\nExtended DNA: Extended '
+                           'IUPAC DNA alphabet.\nIn addition to the standard letter '
+                           'codes GATC, this includes:\n*B* = 5-bromouridine\n'
+                           '*D* = 5,6-dihydrouridine\n*S* = thiouridine\n*W* '
+                           '= wyosine\n\nAmbiguous RNA: Uppercase IUPAC '
+                           'ambiguous RNA; *GAUCRYWSMKHBVDN*\n\nUnambigous '
+                           'RNA alphabet: Generic single letter RNA '
+                           'alphabet.\n\n')
+        form.addParam('inputRawSequence', params.StringParam,
+                      condition='(inputSequence == %d and '
+                                'inputProteinSequence == %d) or '
+                                '(inputSequence == %d and '
+                                'inputNucleotideSequence == %d) ' %
+                                (SEQ_TYPE_AMINOACIDS,
+                                self.IMPORT_FROM_PLAIN_TEXT,
+                                 SEQ_TYPE_NUCLEOTIDES,
+                                 self.IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT),
+                      label="Write your sequence here:", important=True,
+                      help="Write the aminoacid or nucleotide raw sequence.\n")
+        form.addParam('inputStructureSequence', params.EnumParam,
+                      choices=['id', 'file'],
+                      condition='inputProteinSequence == %d or '
+                                'inputNucleotideSequence == %d' %
+                                (self.IMPORT_FROM_STRUCTURE,
+                                 self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE),
+                      label="Atomic structure from",
+                      default=self.IMPORT_STRUCTURE_FROM_ID,
+                      display=params.EnumParam.DISPLAY_HLIST,
+                      help='Import structure data from online server or local '
+                           'file',
+                      pointerClass='PdbFile',
+                      allowsNull=True)
+        form.addParam('pdbId', params.StringParam,
+                      condition='(inputProteinSequence == %d or '
+                                'inputNucleotideSequence == %d) and '
+                                'inputStructureSequence == %d'
+                                % (self.IMPORT_FROM_STRUCTURE,
+                                   self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                                   self.IMPORT_STRUCTURE_FROM_ID),
+                      label="Atomic structure ID ", allowsNull=True,
+                      help='Type a structure ID (four alphanumeric '
+                           'characters).')
+        form.addParam('pdbFile', params.PathParam, label="File path",
+                      condition='(inputProteinSequence == %d or '
+                                'inputNucleotideSequence == %d) and '
+                                'inputStructureSequence == %d'
+                                % (self.IMPORT_FROM_STRUCTURE,
+                                   self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                                   self.IMPORT_STRUCTURE_FROM_FILES),
+                      allowsNull=True,
+                      help='Specify a path to desired atomic structure.')
+        form.addParam('inputStructureChain', params.StringParam,
+                      condition='inputProteinSequence == %d or '
+                                'inputNucleotideSequence == %d' %
+                                (self.IMPORT_FROM_STRUCTURE,
+                                 self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE),
+                      label="Chain ", allowsNull=True,
+                      help="Select a particular chain of the atomic "
+                           "structure.")
+        form.addParam('fileSequence', params.PathParam,
+                      label="File path",
+                      condition='inputProteinSequence == %d or '
+                                'inputNucleotideSequence == %d' %
+                                (self.IMPORT_FROM_FILES,
+                                 self.IMPORT_FROM_NUCLEOTIDE_FILES),
+                      allowsNull=True,
+                      help='Specify a path to desired aminoacid or '
+                           'nucleic acid sequence '
+                           'file.\nIf your file contains more than one '
+                           'sequence, only the first one will be considered.')
+        form.addParam('geneBankSequence', params.StringParam,
+                      condition='inputSequence == %d and '
+                                'inputNucleotideSequence == %d' %
+                                (SEQ_TYPE_NUCLEOTIDES,
+                                self.IMPORT_FROM_GENEBANK),
+                      label="GeneBank accession ", allowsNull=True,
+                      help='Write a GeneBank accession.\n')
+
+    def _insertAllSteps(self):
+        self.name = self.inputSequenceName.get()
+
+        if self.inputSequence == SEQ_TYPE_AMINOACIDS:
+            if self.inputProteinSequence == self.IMPORT_FROM_PLAIN_TEXT:
+                rawSequence = self.inputRawSequence.get()
+                self._insertFunctionStep('getRawSequenceStep', rawSequence)
+            elif self.inputProteinSequence == self.IMPORT_FROM_STRUCTURE:
+                chainId = self.inputStructureChain.get()
+                self._insertFunctionStep('getSequenceOfChainStep', chainId)
+            elif self.inputProteinSequence == self.IMPORT_FROM_UNIPROT:
+                sequenceDB = self._getUniProtID()
+                self._insertFunctionStep('sequenceDatabaseDownloadStep',
+                                         sequenceDB)
+            elif self.inputProteinSequence == self.IMPORT_FROM_FILES:
+                self.sequenceFile = self.fileSequence.get()
+                sequenceFile = self.sequenceFile
+                self._insertFunctionStep('fileDownloadStep', sequenceFile)
+        else:
+            if self.inputNucleotideSequence == \
+                    self.IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT:
+                rawSequence = self.inputRawSequence.get()
+                self._insertFunctionStep('getRawSequenceStep', rawSequence)
+            elif self.inputNucleotideSequence == \
+                     self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE:
+                chainId = self.inputStructureChain.get()
+                self._insertFunctionStep('getSequenceOfChainStep', chainId)
+            elif self.inputNucleotideSequence == self.IMPORT_FROM_GENEBANK:
+                sequenceDB = self._getGeneBankID()
+                self._insertFunctionStep('sequenceDatabaseDownloadStep',
+                                         sequenceDB)
+            elif self.inputNucleotideSequence == \
+                self.IMPORT_FROM_NUCLEOTIDE_FILES:
+                self.sequenceFile = self.fileSequence.get()
+                sequenceFile = self.sequenceFile
+                self._insertFunctionStep('fileDownloadStep', sequenceFile)
+
+        self._insertFunctionStep('createOutputStep')
+
+    def getRawSequenceStep(self, rawSequence):
+        # user types sequence
+        if self.inputSequenceID.get() is not None:
+            self.id = self.inputSequenceID.get()
+        else:
+            self.id = self.name
+        self.alphabet = self._getAlphabet()  # index number
+        self.sequence = cleanSequenceScipion(self.inputSequence ==
+                                     SEQ_TYPE_AMINOACIDS,
+                                      self.alphabet, rawSequence)
+
+    def getSequenceOfChainStep(self, chainId):
+        # sequece is obtained from PDB file
+
+        # form has a wizard that creates label with the format
+        # [model: x, chain: x, xxx residues]
+        selectedModel = chainId.split(',')[0].split(':')[1].strip()
+        selectedChain = chainId.split(',')[1].split(':')[1].strip()
+
+        self.structureHandler = AtomicStructHandler()
+
+        if self.pdbId.get() is not None:
+        # PDB from remote database
+            pdbID = self.pdbId.get()
+            tmpFilePath = os.path.join("/tmp", pdbID + ".cif")
+            if exists(tmpFilePath):
+                # wizard already downloaded the file
+                self.structureHandler.read(tmpFilePath)
+            else:
+                # wizard has not used and the file has not been downloaded yet
+                self.structureHandler.readFromPDBDatabase(pdbID, dir="/tmp")
+        else:
+        # PDB from file
+            self.structureHandler.read(self.pdbFile.get())
+
+        _sequence = self.structureHandler.getSequenceFromChain(
+            selectedModel, selectedChain)
+        self.sequence = str(_sequence)
+        self.alphabet = alphabetToIndex(self.inputSequence ==
+                                        SEQ_TYPE_AMINOACIDS,
+                                        _sequence.alphabet)
+
+        # Assignation of sequence ID: if the user has provided a specific
+        #  ID, this will be adopted by default; otherwise, a sequence ID
+        # related with the starting structure will be selected.
+        if self.inputSequenceID.get() is not None:
+            self.id = self.inputSequenceID.get()
+        else:
+            self.id = self.structureHandler.getFullID(
+                    selectedModel, selectedChain)
+
+        print "Selected chain: %s from model: %s from structure: %s" \
+              % (selectedChain, selectedModel,
+                 self.structureHandler.structure.get_id())
+
+    def sequenceDatabaseDownloadStep(self, sequenceDB):
+        """Download UniProt/GeneBank sequence from its respective database
+        """
+        #sequenceDB = str(sequenceDB)
+        if self.uniProtSequence.get() is not None:
+            seqHandler = SequenceHandler()
+
+        elif self._getGeneBankID() is not None:
+            seqHandler = SequenceHandler(isAminoacid=False)
+
+        record, error = seqHandler.downloadSeqFromDatabase(sequenceDB)
+        if record is None:
+            errorWindow(None, error)
+            self.setAborted()
+            exit(0)
+
+        if self.inputSequenceID.get() is not None:
+            self.id = self.inputSequenceID.get()
+        elif sequenceDB != '':
+            self.id = sequenceDB
+        else:
+            self.id = self.name
+        if record.description != '':
+            self.description = record.description
+
+        self.sequence = str(record.seq)
+        self.alphabet = alphabetToIndex(self.inputSequence ==
+                                     SEQ_TYPE_AMINOACIDS, record.seq.alphabet)
+
+    def fileDownloadStep(self, sequenceFile):
+        # If sequencePath contains more than one sequence, only
+        # the first one will be considered
+        seqHandler = SequenceHandler()
+        record = seqHandler.downloadSeqFromFile(sequenceFile,
+                                                        type="fasta")
+        if self.inputSequenceID.get() is not None:
+            self.id = self.inputSequenceID.get()
+        elif record.id != '':
+            self.id = record.id
+        else:
+            self.id = self.name
+        if record.description != '':
+            self.description = record.description
+
+        self.sequence = str(record.seq)
+        self.alphabet = alphabetToIndex(self.inputSequence ==
+                                     SEQ_TYPE_AMINOACIDS, record.seq.alphabet)
+
+    def createOutputStep(self):
+        """ Register the output object. """
+
+        if self.inputSequenceDescription.get() is not None:
+            self.description = self.inputSequenceDescription.get()
+        elif hasattr(self,'description'):
+            pass
+        else:
+            self.description = ''
+
+        seq = Sequence(name=self.name,
+                       sequence=self.sequence,
+                       alphabet = self.alphabet,
+                       isAminoacids=(self.inputSequence ==
+                                     SEQ_TYPE_AMINOACIDS),
+                       id=self.id, description=self.description)
+        outputs = {'outputSequence': seq}
+        self._defineOutputs(**outputs)
+
+    def _summary(self):
+        summary = []
+        self.name = self.inputSequenceName.get()
+        uniProtId = self._getUniProtID()
+        geneBankID = self._getGeneBankID()
+        if self.inputSequence == SEQ_TYPE_AMINOACIDS:
+            summary.append('Sequence of aminoacids:\n')
+            if self.inputProteinSequence == self.IMPORT_FROM_PLAIN_TEXT:
+                summary.append("Sequence *%s* imported from plain text\n"
+                               % self.name)
+            elif self.inputProteinSequence == self.IMPORT_FROM_STRUCTURE:
+                if self.inputStructureSequence == \
+                    self.IMPORT_STRUCTURE_FROM_ID:
+                    summary.append("Sequence *%s* imported from atomic "
+                                   "structure *%s.cif*\n"
+                                   % (self.name, self.pdbId.get()))
+                elif self.inputStructureSequence == \
+                    self.IMPORT_STRUCTURE_FROM_FILES:
+                    summary.append("Sequence *%s* imported from file *%s*\n"
+                                   % (self.name, self.pdbFile.get()))
+            elif self.inputProteinSequence == self.IMPORT_FROM_UNIPROT:
+                summary.append("Sequence *%s* imported from UniProt ID "
+                               "*%s*\n"
+                               % (self.name, uniProtId))
+            elif self.inputProteinSequence == self.IMPORT_FROM_FILES:
+                summary.append("Sequence *%s* imported from file name: "
+                               "*%s*\n"
+                               % (self.name, self.fileSequence.get()))
+        else:
+            summary.append('Sequence of nucleotides:\n')
+            if self.inputNucleotideSequence == \
+                    self.IMPORT_FROM_NUCLEOTIDE_PLAIN_TEXT:
+                summary.append("Sequence *%s* imported from plain text\n"
+                               % self.name)
+            elif self.inputNucleotideSequence == \
+                    self.IMPORT_FROM_NUCLEOTIDE_STRUCTURE:
+                if self.inputStructureSequence == \
+                    self.IMPORT_STRUCTURE_FROM_ID:
+                    summary.append("Sequence *%s* imported from atomic "
+                                   "structure *%s.cif*\n"
+                                   % (self.name, self.pdbId.get()))
+                elif self.inputStructureSequence == \
+                    self.IMPORT_STRUCTURE_FROM_FILES:
+                    summary.append("Sequence *%s* imported from file *%s*\n"
+                                   % (self.name, self.pdbFile.get()))
+            elif self.inputNucleotideSequence == self.IMPORT_FROM_GENEBANK:
+                summary.append("Sequence *%s* imported from geneBank ID "
+                               "*%s*\n"
+                               % (self.name, geneBankID))
+            elif self.inputNucleotideSequence == \
+                    self.IMPORT_FROM_NUCLEOTIDE_FILES:
+                summary.append("Sequence *%s* imported from file name: "
+                               "*%s*\n"
+                               % (self.name, self.fileSequence.get()))
+        return summary
+
+    def _validate(self):
+        errors = []
+        return errors
+
+    def _getSequenceName(self):
+        pass
+
+    def _getUniProtID(self):
+        return self.uniProtSequence.get()
+
+    def _getGeneBankID(self):
+        return self.geneBankSequence
+
+    def _getAlphabet(self):
+        if self.inputSequence == SEQ_TYPE_AMINOACIDS:
+            return self.proteinIUPACalphabet.get()
+        else:
+            return self.nucleotideIUPACalphabet.get()
+

--- a/pyworkflow/em/protocol/protocol_import/viewer.py
+++ b/pyworkflow/em/protocol/protocol_import/viewer.py
@@ -119,6 +119,7 @@ class viewerProtImportVolumes(ProtocolViewer):
                                      bildFileName=tmpFileNameBILD,
                                      sampling=sampling)
             f.write("open %s\n" % tmpFileNameBILD)
+            f.write("cofr 0,0,0\n")  # set center of coordinates
             count = 1  # skip first model because is not a 3D map
 
         for vol in _setOfVolumes:

--- a/pyworkflow/em/protocol/protocol_import/volumes.py
+++ b/pyworkflow/em/protocol/protocol_import/volumes.py
@@ -58,23 +58,23 @@ class ProtImportVolumes(ProtImportImages):
                       label=Message.LABEL_SAMP_RATE)
         form.addParam('setOrigCoord', params.BooleanParam,
                       label="Set origin of coordinates",
-                      help="Option YES: A new volume will be created with the "
+                      help="Option YES:\nA new volume will be created with "
+                           "the "
                            "given ORIGIN of coordinates. This ORIGIN will be "
-                           "set in the map file header.\n"
-                           # Option YES: The binary of the object volume will 
-                           # be saved with its header modified. 
-                           # Option NO: The binary of the object volume will 
-                           # saved without any modifications. Then, the volume
-                           # is the input volume itself with other filename.
-                           # In this case the coordinates of the origin will
-                           # be saved as SCIPION object, not in the header 
-                           # volume. 
-                           # Volumes are not copied by default. They are only
-                           # copied if the user has selected the option YES in
-                           # the advanced question form "Copy files?"
-                           "Option NO: The ORIGIN of coordinates will be " 
-                           "placed at the center of the whole volume. This "
-                           "ORIGIN will NOT be set in the map file header. \n"
+                           "set in the map file header.\nThe ORIGIN of "
+                           "coordinates will be placed at the center of the "
+                           "whole volume if you select n(x)/2, n(y)/2, "
+                           "n(z)/2 as "
+                           "x, y, z coordinates (n(x), n(y), n(z) are the "
+                           "dimensions of the whole volume). However, "
+                           "selecting "
+                           "0, 0, 0 as x, y, z coordinates, the volume will be "
+                           "placed at the upper right-hand corner.\n\n"
+                           "Option NO:\nThe ORIGIN of coordinates will be " 
+                           "placed at the center of the whole volume ("
+                           "coordinates n(x)/2, n(y)/2, n(z)/2 by default). "
+                           "This "
+                           "ORIGIN will NOT be set in the map file header.\n\n"
                            "WARNING: In case you want to process "
                            "the volume with programs requiring a specific "
                            "symmetry regarding the origin of coordinates, "
@@ -94,11 +94,14 @@ class ProtImportVolumes(ProtImportImages):
                                   "provide the map center coordinates in "
                                   "Angstroms (pixels x sampling).\n",
                             condition='setOrigCoord')
-        line.addParam('x', params.FloatParam, condition='setOrigCoord',
+        # line.addParam would produce a nicer looking form
+        # but them the wizard icon is drawn outside the visible
+        # window. Until this bug is fixed form is a better option
+        form.addParam('x', params.FloatParam, condition='setOrigCoord',
                       label="x", help="offset along x axis (Angstroms)")
-        line.addParam('y', params.FloatParam, condition='setOrigCoord',
+        form.addParam('y', params.FloatParam, condition='setOrigCoord',
                       label="y", help="offset along y axis (Angstroms)")
-        line.addParam('z', params.FloatParam, condition='setOrigCoord',
+        form.addParam('z', params.FloatParam, condition='setOrigCoord',
                       label="z", help="offset along z axis (Angstroms)")
 
     def _insertAllSteps(self):

--- a/pyworkflow/em/viewer.py
+++ b/pyworkflow/em/viewer.py
@@ -51,16 +51,18 @@ from pyworkflow.em import ImageHandler, OrderedDict
 from pyworkflow.viewer import View, Viewer, CommandView, DESKTOP_TKINTER, ProtocolViewer
 from pyworkflow.utils import Environ, runJob, importFromPlugin, getFreePort
 from pyworkflow.gui.matplotlib_image import ImageWindow
+from pyworkflow.gui.text import openTextFile, openTextFileEditor
 
 # From pyworkflow.em level
 import showj
 import metadata as md
-from data import PdbFile
+from data import PdbFile, Sequence
 from convert import ImageHandler
 from pyworkflow.em.viewers.chimera_utils import \
     getChimeraEnviron,  createCoordinateAxisFile
 
 import xmippLib
+from pyworkflow.em.handler_sequence import SequenceHandler
 
 from viewer_fsc import FscViewer
 from viewer_pdf import PDFReportViewer
@@ -488,6 +490,41 @@ class ChimeraDataView(ChimeraClientView):
     def show(self):
         self.dataview.show()
         ChimeraClientView.show(self)
+
+class SequenceViewer(Viewer):
+    """ Wrapper to visualize Sequences with an editor. """
+    _environments = [DESKTOP_TKINTER]
+    _targets = [Sequence]
+
+    def __init__(self, **kwargs):
+        Viewer.__init__(self, **kwargs)
+
+    # def visualize(self, obj, **kwargs):
+        # fn = obj.getFileName()
+        # openTextFileEditor(fn)
+    def visualize(self, obj, **kwargs):
+        ## The sequence object is visualized in a tmp file;
+        ## To build this tmp file we use a method (saveFile) from the class
+        ## SequenceHandler that requires a Biopython sequence (Bio.Seq.Seq
+        ## object);
+
+        # Step 1: transformation of the sequence of our Scipion Sequence
+        # object (obj.getSequence()) in a Biopython Sequence:
+        seqHandler = SequenceHandler(obj.getSequence(),
+                                     isAminoacid=obj.getIsAminoacids())
+        seqBio = seqHandler._sequence  # Bio.Seq.Seq object
+        # Step 2: retrieving of the other args needed in the saveFile method
+        seqID = obj.getId()
+        seqName = obj.getSeqName()
+        seqDescription = obj.getDescription()
+        seqFileName = os.path.abspath(self.protocol._getTmpPath(
+            seqName + ".fasta"))
+        # Step 3: Sequence saved in the tmp file
+        seqHandler.saveFile(seqFileName, seqID, sequence=seqBio,
+                            name=seqName, seqDescription=seqDescription,
+                            type="fasta")
+        # Step 4: Visalization of tmp file
+        openTextFileEditor(seqFileName)
 
 
 class ChimeraViewer(Viewer):

--- a/pyworkflow/tests/em/protocols/test_protocols_import_sequence.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_import_sequence.py
@@ -1,0 +1,579 @@
+# -*- coding: utf-8 -*-
+# **************************************************************************
+# *
+# * Authors:     Marta Martinez (mmmtnez@cnb.csic.es)
+# *              Roberto Marabini (roberto@cnb.csic.es)
+# *
+# * Unidad de  Bioinformatica of Centro Nacional de Biotecnologia , CSIC
+# *
+# * This program is free software; you can redistribute it and/or modify
+# * it under the terms of the GNU General Public License as published by
+# * the Free Software Foundation; either version 2 of the License, or
+# * (at your option) any later version.
+# *
+# * This program is distributed in the hope that it will be useful,
+# * but WITHOUT ANY WARRANTY; without even the implied warranty of
+# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * GNU General Public License for more details.
+# *
+# * You should have received a copy of the GNU General Public License
+# * along with this program; if not, write to the Free Software
+# * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+# * 02111-1307  USA
+# *
+# *  All comments concerning this program package may be sent to the
+# *  e-mail address 'scipion@cnb.csic.es'
+# *
+# **************************************************************************
+
+from pyworkflow.tests import BaseTest, setupTestProject, DataSet
+from pyworkflow.em.protocol.protocol_import.sequence import \
+    ProtImportSequence
+from pyworkflow.em.handler_sequence import \
+    SEQ_TYPE_NUCLEOTIDES, PROTEIN_ALPHABET, \
+    AMBIGOUS_RNA_ALPHABET, indexToAlphabet
+
+
+class TestImportBase(BaseTest):
+    @classmethod
+    def setUpClass(cls):
+        setupTestProject(cls)
+        cls.dsModBuild = DataSet.getDataSet('model_building_tutorial')
+
+
+class TestImportSequence(TestImportBase):
+    USERID = "UserID"
+    NAME = 'USER_SEQ'
+    DESCRIPTION = 'User description'
+    NUCLEOTIDESEQ1 = 'AATGCGGTTGGGBDSW********GGCACACG'
+    AMINOACIDSSEQ1 = 'LARKJLAKPABXZJUO********VAVAVALK'
+    CHAIN1 = "[model: 0, chain: B, 148 residues]" # Protein
+    CHAIN2 = "[model: 0, chain: A, 34 residues]" # RNA
+    CHAIN3 = "[model: 0, chain: I, 153 residues]" # DNA
+    pdbID1 = "3lqd" # Protein
+    pdbID2 = "205d" # RNA
+    pdbID3 = "1aoi" # DNA and protein
+    GENEBANKID = 'AJ520101.1'
+    UNIPROTID = 'P12345'
+
+    def testImportUserNucleotideSequence1(self):
+        """
+        Import a single nucleotide sequence provided by the user (nucleotide
+        alphabet by default)
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputRawSequence': self.NUCLEOTIDESEQ1
+               }
+        prot1 = self.newProtocol(ProtImportSequence, **args)
+        prot1.setObjLabel('1_import nucleotide,\nseq from user\nExtended DNA '
+                           'alphabet')
+        self.launchProtocol(prot1)
+        sequence = prot1.outputSequence
+        self.assertEqual("USER_SEQ", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("AATGCGGTTG", sequence.getSequence()[:10])
+        self.assertEqual("GATCBDSW",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportUserNucleotideSequence2(self):
+        """
+        Import a single nucleotide sequence provided by the user (nucleotide
+        alphabet AMBIGOUS_RNA_ALPHABET)
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'nucleotideIUPACalphabet': AMBIGOUS_RNA_ALPHABET,
+                'inputRawSequence': self.NUCLEOTIDESEQ1
+               }
+        prot2 = self.newProtocol(ProtImportSequence, **args)
+        prot2.setObjLabel('2_import nucleotide,\nseq from user\nAmbigous RNA '
+                           'alphabet')
+        self.launchProtocol(prot2)
+        sequence = prot2.outputSequence
+        self.assertEqual("USER_SEQ", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("AAGCGGGGGB", sequence.getSequence()[:10])
+        self.assertEqual("GAUCRYWSMKHBVDN",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportStructureNucleotideSequence1(self):
+        """
+        Import the sequence of chain A of atomic RNA structure 205d.cif
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_ID,
+                'pdbId': self.pdbID2,
+                'inputStructureChain': self.CHAIN2
+                }
+        prot3 = self.newProtocol(ProtImportSequence, **args)
+        prot3.setObjLabel('3_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot3)
+        sequence = prot3.outputSequence
+        self.assertEqual("205d_A", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("GGACUUUGGU", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportStructureNucleotideSequence2(self):
+        """
+        Import the sequence of chain A of atomic RNA structure 205d.cif
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_FILES,
+                'pdbFile': self.dsModBuild.getFile('PDBx_mmCIF/205d.cif'),
+                'inputStructureChain': self.CHAIN2
+                }
+        prot4 = self.newProtocol(ProtImportSequence, **args)
+        prot4.setObjLabel('4_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot4)
+        sequence = prot4.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("GGACUUUGGU", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportStructureNucleotideSequence3(self):
+        """
+        Import the sequence of chain I of atomic DNA structure 1aoi.cif
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_ID,
+                'pdbId': self.pdbID3,
+                'inputStructureChain': self.CHAIN3
+                }
+        prot5 = self.newProtocol(ProtImportSequence, **args)
+        prot5.setObjLabel('5_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot5)
+        sequence = prot5.outputSequence
+        self.assertEqual("1aoi_I", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("ATCAATATCC", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportStructureNucleotideSequence4(self):
+        """
+        Import the sequence of chain I of atomic DNA structure 1aoi.cif
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_FILES,
+                'pdbFile': self.dsModBuild.getFile('PDBx_mmCIF/1aoi.cif'),
+                'inputStructureChain': self.CHAIN3
+                }
+        prot6 = self.newProtocol(ProtImportSequence, **args)
+        prot6.setObjLabel('6_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot6)
+        sequence = prot6.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("ATCAATATCC", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileNucleotideSequence1(self):
+        """
+        Import a single nucleotide sequence from a text file
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/AJ520101.fasta')
+                }
+        prot7 = self.newProtocol(ProtImportSequence, **args)
+        prot7.setObjLabel('7_import nucleotide,\nseq from file')
+        self.launchProtocol(prot7)
+        sequence = prot7.outputSequence
+        self.assertEqual("AJ520101.1", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("AJ520101.1 Rhizobium leguminosarum bv. viciae "
+                         "plasmid "
+                         "partial fixC gene, fixX gene, nifA gene "
+                         "and nifB gene",
+                        sequence.getDescription())
+        self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileNucleotideSequence2(self):
+        """
+        Import a single nucleotide sequence from a text file
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/AJ520101.fasta')
+                }
+        prot8 = self.newProtocol(ProtImportSequence, **args)
+        prot8.setObjLabel('8_import nucleotide,\nseq from file')
+        self.launchProtocol(prot8)
+        sequence = prot8.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileNucleotideSequence3(self):
+        """
+        Import a single nucleotide sequence from a text file
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/Several_sequences.fasta')
+                }
+        prot9 = self.newProtocol(ProtImportSequence, **args)
+        prot9.setObjLabel('9_import nucleotide,\nseq from file')
+        self.launchProtocol(prot9)
+        sequence = prot9.outputSequence
+        self.assertEqual("Seq1", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("Seq1 This is the sequence number one",
+                         sequence.getDescription())
+        self.assertEqual("TGGCTAAATA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileNucleotideSequence4(self):
+        """
+        Import a single nucleotide sequence from a text file that contains
+        several sequences
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_NUCLEOTIDE_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/Several_sequences.fasta')
+                }
+        prot10 = self.newProtocol(ProtImportSequence, **args)
+        prot10.setObjLabel('10_import nucleotide,\nseq from file')
+        self.launchProtocol(prot10)
+        sequence = prot10.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("TGGCTAAATA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportGeneBankNucleotideSequence1(self):
+        """
+        Import a single nucleotide sequence from GeneBank
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_GENEBANK,
+                'geneBankSequence': self.GENEBANKID
+                }
+        prot11 = self.newProtocol(ProtImportSequence, **args)
+        prot11.setObjLabel('11_import nucleotide,\nseq from '
+                           'GeneBank')
+        self.launchProtocol(prot11)
+        sequence = prot11.outputSequence
+        self.assertEqual("AJ520101.1", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("AJ520101.1 Rhizobium leguminosarum bv. viciae "
+                         "plasmid partial fixC gene, fixX gene, nifA gene "
+                         "and nifB gene",
+                         sequence.getDescription())
+        self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportGeneBankNucleotideSequence2(self):
+        """
+        Import a single nucleotide sequence from GeneBank
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputSequence': SEQ_TYPE_NUCLEOTIDES,
+                'inputNucleotideSequence':
+                    ProtImportSequence.IMPORT_FROM_GENEBANK,
+                'geneBankSequence': self.GENEBANKID
+                }
+        prot12 = self.newProtocol(ProtImportSequence, **args)
+        prot12.setObjLabel('12_import nucleotide,\nseq from '
+                           'GeneBank')
+        self.launchProtocol(prot12)
+        sequence = prot12.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual("User description",
+                         sequence.getDescription())
+        self.assertEqual("GGATCCGAGA", sequence.getSequence()[:10])
+        self.assertEqual("GAUC",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportUserAminoacidSequence1(self):
+        """
+        Import a single aminoacid sequence provided by the user (protein
+        alphabet by default)
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputRawSequence': self.AMINOACIDSSEQ1
+                }
+        prot13 = self.newProtocol(ProtImportSequence, **args)
+        prot13.setObjLabel('13_import aminoacid seq,\n from user\nExtended '
+                           'protein alphabet')
+        self.launchProtocol(prot13)
+
+        sequence = prot13.outputSequence
+        self.assertEqual("USER_SEQ", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description", sequence.getDescription())
+        self.assertEqual("LARKJLAKPA", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWYBXZJUO",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters
+                        )
+
+    def testImportUserAminoacidSequence2(self):
+        """
+        Import a single aminoacid sequence provided by the user (protein
+        alphabet PROTEIN_ALPHABET
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'proteinIUPACalphabet': PROTEIN_ALPHABET,
+                'inputRawSequence': self.AMINOACIDSSEQ1
+                }
+        prot14 = self.newProtocol(ProtImportSequence, **args)
+        prot14.setObjLabel('14_import aminoacid seq,\n from user\nProtein '
+                           'alphabet')
+        self.launchProtocol(prot14)
+        sequence = prot14.outputSequence
+        self.assertEqual("USER_SEQ", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description", sequence.getDescription())
+        self.assertEqual("LARKLAKPAV", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters
+                        )
+
+    def testImportStructureAminoacidSequence1(self):
+        """
+        Import the sequence of chain B of atomic structure 3lqd.cif
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_ID,
+                'pdbId': self.pdbID1,
+                'inputStructureChain': self.CHAIN1
+                }
+        prot15 = self.newProtocol(ProtImportSequence, **args)
+        prot15.setObjLabel('15_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot15)
+        sequence = prot15.outputSequence
+
+        self.assertEqual("3lqd_B", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description", sequence.getDescription())
+        self.assertEqual("VHLSGEEKSA", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportStructureAminoacidSequence2(self):
+        """
+        Import the sequence of chain B of atomic structure 3lqd.cif
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_STRUCTURE,
+                'inputStructureSequence':
+                    ProtImportSequence.IMPORT_STRUCTURE_FROM_FILES,
+                'pdbFile': self.dsModBuild.getFile('PDBx_mmCIF/3lqd.cif'),
+                'inputStructureChain': self.CHAIN1
+                }
+        prot16 = self.newProtocol(ProtImportSequence, **args)
+        prot16.setObjLabel('16_import aminoacid seq,\n from atomic '
+                           'structure')
+        self.launchProtocol(prot16)
+        sequence = prot16.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual("USER_SEQ", sequence.getSeqName())
+        self.assertEqual("User description", sequence.getDescription())
+        self.assertEqual("VHLSGEEKSA", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileAminoacidSequence1(self):
+        """
+        Import a single aminoacid sequence from a text file
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/COX1_human.fasta')
+                }
+        prot17 = self.newProtocol(ProtImportSequence, **args)
+        prot17.setObjLabel('17_import aminoacid,\nseq from file')
+        self.launchProtocol(prot17)
+        sequence = prot17.outputSequence
+
+        self.assertEqual("YP_003024028.1", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual('YP_003024028.1 cytochrome c oxidase '
+                         'subunit I (mitochondrion) [Homo sapiens]',
+                        sequence.getDescription())
+        self.assertEqual("MFADRWLFST", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportFileAminoacidSequence2(self):
+        """
+        Import a single aminoacid sequence from a text file
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_FILES,
+                'fileSequence': self.dsModBuild.getFile(
+                    'Sequences/COX1_human.fasta')
+                }
+        prot18 = self.newProtocol(ProtImportSequence, **args)
+        prot18.setObjLabel('18_import aminoacid,\nseq from file')
+        self.launchProtocol(prot18)
+        sequence = prot18.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual('User description',
+                         sequence.getDescription())
+        self.assertEqual("MFADRWLFST", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportUniprotAminoacidSequence1(self):
+        """
+        Import a single aminoacid sequence from UniProt
+        """
+        args = {'inputSequenceName': self.NAME,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_UNIPROT,
+                'uniProtSequence': self.UNIPROTID
+                }
+        prot19 = self.newProtocol(ProtImportSequence, **args)
+        prot19.setObjLabel('19_import aminoacids,\nseq from '
+                           'UniProt')
+        self.launchProtocol(prot19)
+        sequence = prot19.outputSequence
+        self.assertEqual("P12345", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual('Aspartate aminotransferase, mitochondrial',
+                         sequence.getDescription())
+        self.assertEqual("MALLHSARVL", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+    def testImportUniprotAminoacidSequence2(self):
+        """
+        Import a single aminoacid sequence from UniProt
+        """
+        args = {'inputSequenceID': self.USERID,
+                'inputSequenceName': self.NAME,
+                'inputSequenceDescription': self.DESCRIPTION,
+                'inputProteinSequence':
+                    ProtImportSequence.IMPORT_FROM_UNIPROT,
+                'uniProtSequence': self.UNIPROTID
+                    }
+        prot20 = self.newProtocol(ProtImportSequence, **args)
+        prot20.setObjLabel('20_import aminoacids,\nseq from '
+                            'UniProt')
+        self.launchProtocol(prot20)
+        sequence = prot20.outputSequence
+        self.assertEqual("UserID", sequence.getId())
+        self.assertEqual('USER_SEQ', sequence.getSeqName())
+        self.assertEqual('User description',
+                         sequence.getDescription())
+        self.assertEqual("MALLHSARVL", sequence.getSequence()[:10])
+        self.assertEqual("ACDEFGHIKLMNPQRSTVWY",
+                         indexToAlphabet(sequence.getIsAminoacids(),
+                                         sequence.getAlphabet()).letters)
+
+
+


### PR DESCRIPTION
This fork incorporates:
 1)  a new class that models aminoacid sequences (and it is ready to incorporate nucleotide sequences) .
 2) a set of utilities to read/write sequences  from/to hard disk, aligns them, etc
 3) a similar utility file for PDB data has been updated
 4) the corresponding tests
 5) default viewer for sequences
 6) small modifications in volume viewer so the default rotation center is at (0,0,0)
 7) protocol for sequence import 

New files are:
	new file:   pyworkflow/em/handler_atom_struct.py
	new file:   pyworkflow/em/handler_sequence.py
	new file:   pyworkflow/em/protocol/protocol_import/sequence.py
	new file:   pyworkflow/tests/em/protocols/test_protocols_import_sequence.py

Relevant tests

 scipion test pyworkflow.tests.em.data.test_convert_atom_struct
 scipion test pyworkflow.tests.em.protocols.test_protocols_import_sequence

In the corresponding plugins we will incorporate the protocols that use the sequences