### PR TITLE
install mpi4py 3.0.3

### DIFF
--- a/install/script.py
+++ b/install/script.py
@@ -327,7 +327,7 @@ def defineBinaries(args=None):
     env.addPipModule('poster', '0.8.1', target='poster-0.8.1*')
     env.addPipModule('psutil', '2.1.1', target='psutil-2.1.1*')
     env.addPipModule('biopython', '1.71', target='biopython-1.71*')
-    env.addPipModule('mpi4py', '1.3.1')
+    env.addPipModule('mpi4py', '3.0.0')
     scipy = env.addPipModule('scipy', '0.14.0',
                          default=not noScipy, deps=[lapack, matplotlib])
     env.addPipModule('bibtexparser', '0.6.2')

--- a/pyworkflow/tests/tests.py
+++ b/pyworkflow/tests/tests.py
@@ -106,7 +106,7 @@ class BaseTest(unittest.TestCase):
             print "    FAILED with error: %s\n" % prot.getErrorMessage()
             raise Exception("ERROR launching protocol.")
 
-        if not prot.isFinished() and not prot.useQueue:  # when queued is not finished yet
+        if not prot.isFinished() and not prot.useQueue():  # when queued is not finished yet
             print "\n>>> ERROR running protocol %s" % prot.getRunName()
             raise Exception("ERROR: Protocol not finished")
     

--- a/pyworkflow/utils/mpi.py
+++ b/pyworkflow/utils/mpi.py
@@ -62,7 +62,7 @@ def send(command, comm, dest, tag):
                             "to slave." % os.getpid())
 
     # Receive the result in a non-blocking way too (with irecv())
-    req_recv = comm.irecv(dest=dest, tag=tag)
+    req_recv = comm.irecv(source=dest, tag=tag)
     while True:
         done, result = req_recv.test()
         if done:
@@ -105,7 +105,7 @@ def runJobMPISlave(mpiComm):
     
     while True:
         # Receive command in a non-blocking way
-        req_recv = mpiComm.irecv(dest=0, tag=TAG_RUN_JOB+rank)
+        req_recv = mpiComm.irecv(source=0, tag=TAG_RUN_JOB+rank)
         while True:
             done, command = req_recv.test()
             if done:


### PR DESCRIPTION
previous mpi python version didn't work for modern openMPI versions like 3.0. This has fixed my errors.

I've trested mpi with scipion test xmipp3.tests.test_protocols_xmipp_mics.TestXmippExtractParticles
But none of the protocols inside used mpi. So I manually run one with mpi.

use source, instead of dest for irecv
fix bug in test.py --> useQueue()