### PR TITLE
Add indexes and pragma instruction for database

### DIFF
--- a/config/templates/protocols.template
+++ b/config/templates/protocols.template
@@ -212,7 +212,6 @@ Protocols SPA = [
 				{"tag": "protocol", "value": "ProtRelionSubtract",  "text": "default"},
 				{"tag": "protocol", "value": "XmippProtConvertToPseudoAtoms", "text": "default"},
 				{"tag": "protocol", "value": "AtsasProtConvertPdbToSAXS", "text": "default"},
-                {"tag": "protocol", "value": "XmippProtCombinePdb", "text": "default"}
 			]}
 		]},
 		{"tag": "protocol_group", "text": "Reconstruct", "openItem": "False", "children": [

--- a/config/templates/protocols.template
+++ b/config/templates/protocols.template
@@ -211,7 +211,7 @@ Protocols SPA = [
                 {"tag": "protocol", "value": "XmippProtSubtractProjection", "text": "default"},
 				{"tag": "protocol", "value": "ProtRelionSubtract",  "text": "default"},
 				{"tag": "protocol", "value": "XmippProtConvertToPseudoAtoms", "text": "default"},
-				{"tag": "protocol", "value": "AtsasProtConvertPdbToSAXS", "text": "default"},
+				{"tag": "protocol", "value": "AtsasProtConvertPdbToSAXS", "text": "default"}
 			]}
 		]},
 		{"tag": "protocol_group", "text": "Reconstruct", "openItem": "False", "children": [

--- a/pyworkflow/em/protocol/protocol.py
+++ b/pyworkflow/em/protocol/protocol.py
@@ -53,7 +53,7 @@ class EMProtocol(Protocol):
     def __init__(self, **kwargs):
         Protocol.__init__(self, **kwargs)
         
-    def __createSet(self, SetClass, template, suffix):
+    def __createSet(self, SetClass, template, suffix, **kwargs):
         """ Create a set and set the filename using the suffix. 
         If the file exists, it will be delete. """
         setFn = self._getPath(template % suffix)
@@ -62,23 +62,27 @@ class EMProtocol(Protocol):
         cleanPath(setFn)
         
         SqliteDb.closeConnection(setFn)        
-        setObj = SetClass(filename=setFn)
+        setObj = SetClass(filename=setFn, **kwargs)
         return setObj
     
     def _createSetOfMicrographs(self, suffix=''):
         return self.__createSet(SetOfMicrographs,
-                                'micrographs%s.sqlite', suffix)
+                                'micrographs%s.sqlite', suffix,
+                                indexes=['_index'])
     
     def _createSetOfCoordinates(self, micSet, suffix=''):
         coordSet = self.__createSet(SetOfCoordinates,
-                                    'coordinates%s.sqlite', suffix)
+                                    'coordinates%s.sqlite', suffix,
+                                    indexes=['_micId'])
         coordSet.setMicrographs(micSet)       
         return coordSet
 
     def _createCoordinatesTiltPair(self, micTiltPairs, uCoords, tCoords,
                                    angles, suffix):
         coordTiltPairs = self.__createSet(CoordinatesTiltPair,
-                                          'coordinates_pairs%s.sqlite', suffix)
+                                          'coordinates_pairs%s.sqlite', suffix,
+                                          indexes=['_untilted._micId',
+                                                   '_tilted._micId'])
         coordTiltPairs.setUntilted(uCoords)
         coordTiltPairs.setTilted(tCoords)
         coordTiltPairs.setAngles(angles)
@@ -98,7 +102,8 @@ class EMProtocol(Protocol):
         return self.__createSet(SetOfImages, 'images%s.sqlite', suffix)
 
     def _createSetOfParticles(self, suffix=''):
-        return self.__createSet(SetOfParticles, 'particles%s.sqlite', suffix)
+        return self.__createSet(SetOfParticles, 'particles%s.sqlite', suffix,
+                                indexes=['_classId', '_micId'])
 
     def _createSetOfAverages(self, suffix=''):
         return self.__createSet(SetOfAverages, 'averages%s.sqlite', suffix)

--- a/pyworkflow/em/protocol/protocol_particles.py
+++ b/pyworkflow/em/protocol/protocol_particles.py
@@ -412,6 +412,15 @@ class ProtExtractParticles(ProtParticles):
         coordSet._xmippMd = String()
         coordSet.loadAllProperties()
 
+        # TODO: horrible code. Rewrite using
+        # for coord in coordSet.iterItems(orderBy='_micId',
+        #                                 direction='ASC'):
+        #     micId = coord.getMicId()
+        #     if micId != lastMicId:
+        #         lastMicId = micId
+        #         ...
+        #     ...
+
         for micKey, mic in micDict.iteritems():
             if counter % 50 == 0:
                 b = datetime.now()

--- a/pyworkflow/mapper/sqlite.py
+++ b/pyworkflow/mapper/sqlite.py
@@ -722,9 +722,9 @@ class SqliteFlatMapper(Mapper):
             # important that the data access.
 
             # uncommenting these pragmas increase the speed
-            # by a factor of two if python object is manipulated
-            # unfortunately, any interesting operation involve
-            # creation and manipulation of python object that take
+            # by a factor of two if NO python object is manipulated.
+            # Unfortunately, any interesting operation involve
+            # creation and manipulation of python objects that take
             # longer than the access time to the database
             pragmas = {
                 #0 | OFF | 1 | NORMAL | 2 | FULL | 3 | EXTRA;
@@ -734,7 +734,7 @@ class SqliteFlatMapper(Mapper):
                 # FILE 0 | DEFAULT | 1 | FILE | 2 | MEMORY;
                 ##'temp_store': 'MEMORY',
                 # PRAGMA schema.cache_size = pages;
-                ##'cache_size': '5000' # versus 5000
+                ##'cache_size': '5000' # versus -2000
             }
             self.db = SqliteFlatDb(dbName, tablePrefix,
                                    pragmas=pragmas, indexes=indexes)

--- a/pyworkflow/object.py
+++ b/pyworkflow/object.py
@@ -11,7 +11,7 @@
 # *
 # * This program is distributed in the hope that it will be useful,
 # * but WITHOUT ANY WARRANTY; without even the implied warranty of
-# * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# * MERCHANTABIlITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 # * GNU General Public License for more details.
 # *
 # * You should have received a copy of the GNU General Public License
@@ -1008,7 +1008,9 @@ class Set(OrderedObject):
         self.setMapperClass(mapperClass)
         self._mapperPath = CsvList() # sqlite filename
         self._representative = None
-        self._classesDict = classesDict 
+        self._classesDict = classesDict
+        self._indexes = kwargs.get('indexes', [])
+
         # If filename is passed in the constructor, it means that
         # we want to create a new object, so we need to delete it if
         # the file exists
@@ -1114,7 +1116,7 @@ class Set(OrderedObject):
         if self._mapperPath.isEmpty():
             raise Exception("Set.load:  mapper path and prefix not set.")
         fn, prefix = self._mapperPath
-        self._mapper = self._MapperClass(fn, self._loadClassesDict(), prefix)            
+        self._mapper = self._MapperClass(fn, self._loadClassesDict(), prefix, self._indexes)
         self._size.set(self._mapper.count())
         self._idCount = self._mapper.maxId()
            

--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -344,7 +344,7 @@ class TestSetOfMicrographs(BaseTest):
             self.assertTrue(mic.equalAttributes( mic2))
             counter += 1
 
-    def test_tester(self):
+    def test_mapper(self):
         """ test that indexes are created when a
         setOfParticles is created """
         MICNUMBER = 10
@@ -517,7 +517,7 @@ class TestSetOfParticles(BaseTest):
         # before accessing items db        
         imgSet.getFirstItem()
 
-    def test_tester(self):
+    def test_mapper(self):
         """ test that indexes are created when a
         setOfParticles is created """
         PARTNUMBER = 10
@@ -547,7 +547,7 @@ class TestSetOfCoordinates(BaseTest):
     def setUpClass(cls):
         setupTestOutput(cls)
 
-    def test_tester(self):
+    def test_mapper(self):
         """ test that indexes are created when a
         setOfCoordinates is created """
         PARTNUMBER = 10
@@ -832,7 +832,7 @@ class TestCoordinatesTiltPair(BaseTest):
     def setUpClass(cls):
         setupTestOutput(cls)
 
-    def test_tester(self):
+    def test_mapper(self):
         """ test that indexes are created when a
         setOfCoordinates is created """
         MICNUMBER = 10
@@ -856,7 +856,7 @@ class TestCoordinatesTiltPair(BaseTest):
         # that a need to create a set of micTiltPairs
         # and two sets of coordinates but the person who
         # added that data type Should provide a clear test
-        # when this is done then I will finish the test_tester
+        # when this is done then I will finish the test_mapper
 
 class TestCoordinatesTiltPair(BaseTest):
     # TODO: A proper test for SetOfMovieParticles is missing
@@ -864,11 +864,11 @@ class TestCoordinatesTiltPair(BaseTest):
     def setUpClass(cls):
         setupTestOutput(cls)
 
-    def test_tester(self):
+    def test_mapper(self):
         """ test that indexes are created when a
         SetOfMovieParticles is created """
         # TODO I do not see any example on how to create
         # a set of SetOfMovieParticles. The person who
         # added that data type should provide a clear test
-        # when this is done then I will finish the test_tester
+        # when this is done then I will finish the test_mapper
         pass

--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -7,11 +7,50 @@ Created on May 20, 2013
 from glob import iglob
 from pyworkflow.tests import *
 import pyworkflow.utils as pwutils
-
+import sqlite3
+from pyworkflow.utils import Timer
 try:
     from xmipp3.convert import *
 except:
     pwutils.pluginNotFound('xmipp', doRaise=True)
+
+# set to true if you want to check how fast is the access to
+# the database
+SPEEDTEST = True
+
+def getIndex(fileName):
+    """ Returns list of indexes for the table 'objects'
+    in the database fileName"""
+    conn = sqlite3.connect(fileName)
+    cur = conn.cursor()
+    cur.execute("PRAGMA index_list(objects);")
+    rows = cur.fetchall()
+    conn.close()
+    return rows  # list with index names
+
+def dropIndex(fileName, indexName):
+    """ Drop index called indexName for table objects
+    in database fileName"""
+    conn = sqlite3.connect(fileName)
+    cur = conn.cursor()
+    cur.execute("DROP INDEX %s" % indexName)
+    conn.close()
+
+def createDummyProtocol(projName):
+    """create a dummy protocol, returns protocol object"""
+    proj = Manager().createProject(projName)
+    os.chdir(proj.path)
+
+    from pyworkflow.em.protocol import EMProtocol
+
+    prot = proj.newProtocol(EMProtocol)
+    prot.setObjLabel('dummy protocol')
+    try:
+        proj.launchProtocol(prot)
+    except Exception as e:
+        print (str(e))
+    return prot
+ 
 
 
 class TestFSC(unittest.TestCase):
@@ -305,6 +344,30 @@ class TestSetOfMicrographs(BaseTest):
             self.assertTrue(mic.equalAttributes( mic2))
             counter += 1
 
+    def test_tester(self):
+        """ test that indexes are created when a
+        setOfParticles is created """
+        MICNUMBER = 10
+        indexesNames = ['_index']
+        prot = createDummyProtocol("dummy_protocol")
+
+        # create set of micrographs
+        micSet = prot._createSetOfMicrographs()
+        mic = Micrograph()
+        for i in range(MICNUMBER+ 1):
+            mic.setLocation(i, "stack.stk")
+            micSet.append(mic)
+            mic.cleanObjId()
+            micSet.write()
+
+        # check defined indexes
+        setOfMicrographsFileName = prot._getPath("micrographs.sqlite")
+        # print os.path.abspath(setOfPArticleFileName)
+        indexes = sorted([index[1] for index in
+                          getIndex(setOfMicrographsFileName)])
+        for index, indexName in zip(indexes, indexesNames):
+            self.assertEqual(index, 'index_' + indexName )
+
 
 class TestSetOfParticles(BaseTest):
     """ Check if the information of the images is copied to another image when
@@ -315,7 +378,7 @@ class TestSetOfParticles(BaseTest):
     @classmethod
     def setUpClass(cls):
         setupTestOutput(cls)
-        cls.dataset = DataSet.getDataSet('xmipp_tutorial')  
+        cls.dataset = DataSet.getDataSet('xmipp_tutorial')
         
     def test_orderBy(self):
         #create setofProjections sorted
@@ -454,6 +517,131 @@ class TestSetOfParticles(BaseTest):
         # before accessing items db        
         imgSet.getFirstItem()
 
+    def test_tester(self):
+        """ test that indexes are created when a
+        setOfParticles is created """
+        PARTNUMBER = 10
+        indexesNames = ['_classId', '_micId']
+        prot = createDummyProtocol("dummy_protocol")
+
+        # create set of particles
+        partSet = prot._createSetOfParticles()
+        part = Particle()
+        for i in range(PARTNUMBER+ 1):
+            part.setLocation(i, "stack.vol")
+            partSet.append(part)
+            part.cleanObjId()
+        partSet.write()
+
+        # check defined indexes
+        setOfPArticleFileName = prot._getPath("particles.sqlite")
+        # print os.path.abspath(setOfPArticleFileName)
+        indexes = sorted([index[1] for index in
+                          getIndex(setOfPArticleFileName)])
+        for index, indexName in zip(indexes, indexesNames):
+            self.assertEqual(index, 'index_' + indexName )
+
+class TestSetOfCoordinates(BaseTest):
+    # TODO: A proper test for setOfCoordinates is missing
+    @classmethod
+    def setUpClass(cls):
+        setupTestOutput(cls)
+
+    def test_tester(self):
+        """ test that indexes are created when a
+        setOfCoordinates is created """
+        PARTNUMBER = 10
+        MICNUMBER = 600
+        NUMBERCOORDINATES = PARTNUMBER * MICNUMBER
+        indexesNames = ['_micId']
+        prot = createDummyProtocol("dummy_protocol")
+
+        # create set of micrographs
+        micSet = SetOfMicrographs(filename=":memory:")
+        mic = Micrograph()
+        for i in range(NUMBERCOORDINATES):
+            mic.setLocation(i, "mic_%06d.mrc" % i)
+            micSet.append(mic)
+            mic.cleanObjId()
+        micSet.write()
+
+        # create a set of particles
+        coordSet = prot._createSetOfCoordinates(micSet)
+        coord = Coordinate()
+        for i in range(NUMBERCOORDINATES):
+            coordSet.append(coord)
+            coord.cleanObjId()
+        coordSet.write()
+
+        # check defined indexes
+        setOfCoordinatesFileName = \
+            prot._getPath("coordinates.sqlite")
+        print os.path.abspath(setOfCoordinatesFileName)
+        indexes = sorted([index[1] for index in
+                          getIndex(setOfCoordinatesFileName)])
+        for index, indexName in zip(indexes, indexesNames):
+            self.assertEqual(index, 'index_' + indexName )
+
+        # Test speed: based on loop in file protocol_extractparticles.py
+        # for 600 mic and 100 part the values for the first
+        # second and third  case where:
+        # Loop with index: 5 sec
+        # Loop no index: 8:01 min
+        # Loop optimized code: 4 sec
+        # for 6000 mic and 200 part the values for the first
+        # Loop with index: 1:47 min
+        # optimized Loop with index: 1:20 min
+        # Loop no index: after several  hours I stopped the process
+
+        SPEEDTEST = True
+        if SPEEDTEST: # code from protocol_particles. line 415
+            testTimer = Timer()
+            testTimer.tic()
+            for mic in micSet:
+                micId = mic.getObjId()
+                coordList = []
+                for coord in coordSet.iterItems(where='_micId=%s' % micId):
+                    coordList.append(coord.clone())
+            testTimer.toc("Loop with INDEX took:")
+
+            lastMicId = None
+            testTimer.tic()
+            for coord in coordSet.iterItems(orderBy='_micId',
+                                                   direction='ASC'):
+                micId = coord.getMicId()
+                if micId != lastMicId:
+                    lastMicId = micId
+                    coordList = []
+                coordList.append(coord.clone())
+            testTimer.toc("Loop with INDEX and proper code, took:")
+
+            # delete INDEX, this will not work
+            # if database is not sqlite
+            conn = sqlite3.connect(setOfCoordinatesFileName)
+            cur = conn.cursor()
+            for index in indexesNames:
+                cur.execute("DROP INDEX index_%s" % index)
+            cur.close()
+            conn.close()
+
+            testTimer.tic()
+            for mic in micSet:
+                micId = mic.getObjId()
+                coordList = []
+                for coord in coordSet.iterItems(where='_micId=%s' % micId):
+                    coordList.append(coord.clone())
+            testTimer.toc("Loop with NO INDEX took:")
+
+            lastMicId = None
+            testTimer.tic()
+            for coord in coordSet.iterItems(orderBy='_micId',
+                                                   direction='ASC'):
+                micId = coord.getMicId()
+                if micId != lastMicId:
+                    lastMicId = micId
+                    coordList = []
+                coordList.append(coord.clone())
+            testTimer.toc("Loop with NO INDEX but proper code, took:")
 
 class TestSetOfClasses2D(BaseTest):
 
@@ -638,3 +826,49 @@ class TestCopyItems(BaseTest):
         item._list.set([1.0, 2.0])
 
 
+class TestCoordinatesTiltPair(BaseTest):
+    # TODO: A proper test for CoordinatesTiltPair is missing
+    @classmethod
+    def setUpClass(cls):
+        setupTestOutput(cls)
+
+    def test_tester(self):
+        """ test that indexes are created when a
+        setOfCoordinates is created """
+        MICNUMBER = 10
+        indexesNames = ['_untilted._micId',
+                        '_tilted._micId']
+        prot = createDummyProtocol("dummy_protocol")
+
+        # create set of untilted and tilted micrographs
+        uMicSet = SetOfMicrographs(filename=":memory:")
+        tMicSet = SetOfMicrographs(filename=":memory:")
+        mic = Micrograph()
+        for i in range(MICNUMBER):
+            mic.setLocation(i, "umic_%06d.mrc" % i)
+            uMicSet.append(mic)
+            mic.cleanObjId()
+            mic.setLocation(i, "tmic_%06d.mrc" % i)
+            tMicSet.append(mic)
+            mic.cleanObjId()
+        # TODO I do not see any example on how to create
+        # a set of CoordinatesTiltPair. I can image
+        # that a need to create a set of micTiltPairs
+        # and two sets of coordinates but the person who
+        # added that data type Should provide a clear test
+        # when this is done then I will finish the test_tester
+
+class TestCoordinatesTiltPair(BaseTest):
+    # TODO: A proper test for SetOfMovieParticles is missing
+    @classmethod
+    def setUpClass(cls):
+        setupTestOutput(cls)
+
+    def test_tester(self):
+        """ test that indexes are created when a
+        SetOfMovieParticles is created """
+        # TODO I do not see any example on how to create
+        # a set of SetOfMovieParticles. The person who
+        # added that data type should provide a clear test
+        # when this is done then I will finish the test_tester
+        pass


### PR DESCRIPTION
The **aim** of this commit is to **speed up searchs in metadatas.** Jaime Martin Benito reported that extracting particles form a large dataset (6000 micrographs and 150 coordinates per micrograph) spent several hours converting the coordinate fle (in sqlite) to xmipp (pos) coordinate files.

The more consuming code was the loop

```
        for micKey, mic in micDict.iteritems():
            if counter % 50 == 0:
                b = datetime.now()
                print b-a, 'reading coordinates for mic number', "%06d" % counter
                sys.stdout.flush()  # force buffer to print
            counter += 1

            micId = mic.getObjId()
            coordList = []
            self.debug("Loading coords for mic: %s (%s)" % (micId, micKey))
            for coord in coordSet.iterItems(where='_micId=%s' % micId):

```
In order to reduce the serching time we explore the posibility od adding pragma to the database and indexes.

=========================================================
**1st step)**

Follows a description of the preliminary research: first I measure the number of rows per second that sqlite may read/write under different conditions. With that aim I used the files 

- [select.txt](https://github.com/I2PC/scipion/files/2705332/select.txt)
- [bench.txt](https://github.com/I2PC/scipion/files/2705333/bench.txt)

_Bench_ inserts row under different conditions while _select_ search for rows. Bench shows that choosing properly the value of pragmas:

- 'synchronous': 'OFF'
- 'journal_mode': 'OFF'
- 'temp_store': 'MEMORY'
- 'cache_size': '5000'

Conclusions:

- you can improve insert speed by a factor of 20 (for 1000000 rows).  
- On the other hand,  _Select_  (for 1000000 rows) can be speed up by a factor of 100 using indexes
- Inserting when two indexes are defined is about 20% slower

========================================================================
**2nd Step**
 
Then using the code provided in test_data.py: TestSetOfCoordinates I compared insertion speed under different pragma values. No difference in insertion time was measured. After that I study how scipion saves data do sqlite databases and mimic it in the becnh.py file (the more important feature is that scipion does not commit the insertions until the setofObjects was been fully created). becnh.py suggested that choosing the pragma properlly a speed improvement of 2 should be obtained. 

Conclusion is: 

- In insertion mode the time python spends handling the python objects is greater than the time needed to save the data to the databse, 
- Optimizing the database access parameters for insertion will not improve the insertion rate 
- create indexes will not penalize insertion time since the database spends more of the time waiting for the next insertion.
============================================================================
**3rd step** 
The situation is different for select. Searching is much faster with indexes. In fact, the search that required several hours in "protocol_particles.py" now it done in 1 minute.
-----------------------------------------
Conclusion: Insertion is not improved by wise use of pragmas but search must be,

IMPORTANT:  "protocol_particles.py"  is greatelly improved by the use of indexes but...  "protocol_particles.py" is poorly written. If we rewrite the code as

```
            for coord in coordSet.iterItems(orderBy='_micId',
                                                   direction='ASC'):
                micId = coord.getMicId()
                if micId != lastMicId:
                    lastMicId = micId
                    .-.-
                .-.-

```
then the use of indexes only improve the search time in 15%.

In summary, it is a good idea to active indexes by default since they do not slow insertion and
may improve a lot the code. If the code has been carefully written this improvement may be small but for poorly written code the improvement may be dramatic

TEST: in file test data search for test_mapper tests