### PR TITLE
Add new method to atomic_struct.py that can extract a particular chain from an atomic model

### DIFF
--- a/pyworkflow/em/convert/atom_struct.py
+++ b/pyworkflow/em/convert/atom_struct.py
@@ -36,6 +36,7 @@ import numpy
 from collections import defaultdict
 
 import Bio.PDB.Atom
+from Bio.PDB.Dice import ChainSelector
 from Bio.PDB.MMCIFParser import MMCIFParser
 from Bio.PDB.PDBParser import PDBParser
 from Bio.PDB import PDBIO, MMCIFIO
@@ -48,7 +49,8 @@ from Bio.PDB.Polypeptide import is_aa
 from Bio.PDB.Polypeptide import three_to_one
 from Bio.Seq import Seq
 from Bio.Alphabet import IUPAC
-from .transformations import rotation_from_matrix, translation_from_matrix
+from .transformations import rotation_from_matrix, \
+    translation_from_matrix
 from .sequence import SequenceHandler
 
 
@@ -640,6 +642,16 @@ class AtomicStructHandler:
         if outPDBfileName is not None:
             self.write(outPDBfileName)
 
+    def extractChain(self, chainID, start=0, end=-1,
+                     modelID='0', filename="output.mmcif"):
+        """Code for chopping  a structure.
+        This module is used internally by the Bio.PDB.extract() function.
+        """
+        sel = ChainSelector(chain_id=chainID, start=start,
+                            end=end, model_id=int(modelID))
+        io = scipionMMCIFIO()
+        io.set_structure(self.structure)
+        io.save(filename, sel)
 
 def cifToPdb(fnCif,fnPdb):
     h = AtomicStructHandler()

--- a/pyworkflow/em/protocol/protocol_import/sequence.py
+++ b/pyworkflow/em/protocol/protocol_import/sequence.py
@@ -311,8 +311,11 @@ class ProtImportSequence(ProtImportFiles):
 
         # form has a wizard that creates label with the format
         # [model: x, chain: x, xxx residues]
-        selectedModel = chainId.split(',')[0].split(':')[1].strip()
-        selectedChain = chainId.split(',')[1].split(':')[1].strip()
+        import json
+        chainIdDict = json.loads(self.inputStructureChain.get())
+
+        selectedModel = chainIdDict['model']
+        selectedChain = chainIdDict['chain']
 
         self.structureHandler = AtomicStructHandler()
 

--- a/pyworkflow/tests/em/data/test_convert_atom_struct.py
+++ b/pyworkflow/tests/em/data/test_convert_atom_struct.py
@@ -451,8 +451,8 @@ class TestAtomicStructHandler(unittest.TestCase):
         os.unlink(outFile)
 
     def testFunctionAddStructNewModel(self):
-        pdbID1 = '1P30'  # A,B,C
-        pdbID2 = '1CJD'  # A
+        pdbID1 = '1P30'  # A
+        pdbID2 = '1CJD'  # A, B,C
         outFile = "/tmp/model.cif"
         aSH1 = AtomicStructHandler()
         aSH2 = AtomicStructHandler()
@@ -476,6 +476,31 @@ class TestAtomicStructHandler(unittest.TestCase):
         os.unlink(fileName1)
         os.unlink(fileName2)
         os.unlink(outFile)
+
+    def testFunctionSelectChain(self):
+        pdbID1 = '1P30'  # A,B,C
+        outFile = "/tmp/model.cif"
+        aSH1 = AtomicStructHandler()
+        aSH2 = AtomicStructHandler()
+        #
+        fileName1 = aSH1.readFromPDBDatabase(pdbID1, type='mmCif', dir='/tmp')
+        atomsNum1 = len([atom.id for atom in aSH1.getStructure().get_atoms()])
+        #
+        chainID = 'A'
+        outFileName = "/tmp/output.mmcif"
+        aSH1.extractChain(chainID=chainID, modelID='0', end=20,
+                          filename=outFileName)
+        chains = [chain.id for chain in aSH1.getStructure().get_chains()]
+        # compare unordered lists of chains
+        goal = chainID
+        self.assertTrue(Counter(chains) == Counter(goal),
+                        "{} != {}".format(chains, goal))
+        aSH2.read(outFileName)
+        atomsNumT = len([atom.id for atom in aSH2.getStructure().get_atoms()])
+        self.assertEqual(122, atomsNumT)
+
+        #os.unlink(fileName1)
+        #os.unlink(outFile)
 
     @classmethod
     def tearDownClass(cls):


### PR DESCRIPTION
Added method "extractChain" to atom_struct.py that is able to extract a chain from an atomic struct. A corresponding wizard has been implemented

TEST: ./scipion test pyworkflow.tests.em.data.test_convert_atom_struct.TestAtomicStructHandler.testFunctionSelectChain

The wizard is used by "import_sequence" protocol and scipion-em-atom_struct_utils which is a new plug-in
