### PR TITLE
Refactorization of outputs using _outputs List

### DIFF
--- a/pyworkflow/em/protocol/protocol_batch.py
+++ b/pyworkflow/em/protocol/protocol_batch.py
@@ -447,7 +447,7 @@ class ProtUserSubSet(BatchProtocol):
             if isinstance(inputObj, EMSet):
                 inputStr += ' of size %s' % inputObj.getSize()
         output = ''
-        for _, attr in self.iterOutputAttributes(EMObject):
+        for _, attr in self.iterOutputAttributes():
             output += attr.getClassName()
             if isinstance(attr, EMSet):
                 output += ' of size %s' % attr.getSize()

--- a/pyworkflow/em/protocol/protocol_particles_picking.py
+++ b/pyworkflow/em/protocol/protocol_particles_picking.py
@@ -75,7 +75,7 @@ class ProtParticlePicking(ProtParticles):
                               self.getInputMicrographs().getSize()))
 
         if self.getOutputsSize() >= 1:
-            for key, output in self.iterOutputAttributes(EMObject):
+            for key, output in self.iterOutputAttributes():
                 msg = self.getMethods(output)
                 methodsMsgs.append("%s: %s"%(self.getObjectTag(output), msg))
         else:
@@ -90,7 +90,7 @@ class ProtParticlePicking(ProtParticles):
                            % self.getInputMicrographs().getSize())
 
         if self.getOutputsSize() >= 1:
-            for key, output in self.iterOutputAttributes(EMObject):
+            for key, output in self.iterOutputAttributes():
                 summary.append("*%s:* \n %s " % (key, output.getObjComment()))
         else:
             summary.append(Message.TEXT_NO_OUTPUT_CO)

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -358,7 +358,7 @@ class SubclassesTreeProvider(TreeProvider):
                     p = pwobj.Pointer(prot)
                     objects.append(p)
                 
-                for paramName, attr in prot.iterOutputEM():
+                for paramName, attr in prot.iterOutputAttributes():
                     def _checkParam(paramName, attr):
                         # If attr is a sub-classes of any desired one, add it to the list
                         # we should also check if there is a condition, the object 

--- a/pyworkflow/gui/project/viewprotocols.py
+++ b/pyworkflow/gui/project/viewprotocols.py
@@ -437,7 +437,7 @@ class RunIOTreeProvider(pwgui.tree.TreeProvider):
                 inputs.append(attr)
 
             outputs = [attr for _, attr in
-                       self.protocol.iterOutputAttributes(em.EMObject)]
+                       self.protocol.iterOutputAttributes()]
             self.outputStr = pwobj.String(Message.LABEL_OUTPUT)
             objs = inputParents + inputs + [self.outputStr] + outputs
         return objs
@@ -1522,7 +1522,7 @@ class ProtocolsView(tk.Frame):
     def toggleDataSelection(self, prot, append):
 
         # Go through the data selection
-        for paramName, output in prot.iterOutputEM():
+        for paramName, output in prot.iterOutputAttributes():
             if append:
                 self.settings.dataSelection.append(output.getObjId())
             else:
@@ -1918,7 +1918,7 @@ class ProtocolsView(tk.Frame):
             else:
                 firstViewer.visualize(prot)
         else:
-            for _, output in prot.iterOutputAttributes(em.EMObject):
+            for _, output in prot.iterOutputAttributes():
                 viewers = em.findViewers(output.getClassName(), DESKTOP_TKINTER)
                 if len(viewers):
                     # Instanciate the first available viewer

--- a/pyworkflow/project/project.py
+++ b/pyworkflow/project/project.py
@@ -718,7 +718,7 @@ class Project(object):
                 oKey = iAttr.getExtended()
                 matches.append((oKey, iKey))
             else:
-                for oKey, oAttr in node.run.iterOutputAttributes(em.EMObject):
+                for oKey, oAttr in node.run.iterOutputAttributes():
                     if oAttr.getObjId() == iAttr.get().getObjId():
                         matches.append((oKey, iKey))
 
@@ -1165,7 +1165,7 @@ class Project(object):
             n.run = r
             n.setLabel(r.getRunName())
             outputDict[r.getObjId()] = n
-            for _, attr in r.iterOutputAttributes(em.EMObject):
+            for _, attr in r.iterOutputAttributes():
                 # mark this output as produced by r
                 outputDict[attr.getObjId()] = n
 
@@ -1213,7 +1213,7 @@ class Project(object):
         runs = self.getRuns(refresh=refresh)
 
         for r in runs:
-            for paramName, attr in r.iterOutputAttributes(em.EMObject):
+            for paramName, attr in r.iterOutputAttributes():
                 p = pwobj.Pointer(r, extended=paramName)
                 node = g.createNode(p.getUniqueId(), attr.getNameId())
                 node.pointer = p
@@ -1387,7 +1387,7 @@ class Project(object):
         for prot in runs:
             broken = False
             if isinstance(prot, em.ProtImport):
-                for _, attr in prot.iterOutputEM():
+                for _, attr in prot.iterOutputAttributes():
                     fn = attr.getFiles()
                     for f in attr.getFiles():
                         if ':' in f:

--- a/pyworkflow/protocol/protocol.py
+++ b/pyworkflow/protocol/protocol.py
@@ -25,11 +25,6 @@
 # **************************************************************************
 from __future__ import print_function
 
-import traceback
-
-from pyworkflow.em import EMObject
-from pyworkflow.utils import printTraceBack
-
 """
 This modules contains classes required for the workflow
 execution and tracking like: Step and Protocol

--- a/pyworkflow/tests/em/protocols/test_protocols_sets.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_sets.py
@@ -143,7 +143,7 @@ class TestSets(BaseTest):
     @staticmethod
     def outputs(p):
         """Iterator over all the elements in the outputs of protocol p."""
-        for key, output in p.iterOutputEM():
+        for key, output in p.iterOutputAttributes():
             yield output
 
     #

--- a/pyworkflow/tests/test_protocol_output.py
+++ b/pyworkflow/tests/test_protocol_output.py
@@ -23,6 +23,7 @@
 # *  e-mail address 'scipion@cnb.csic.es'
 # *
 # **************************************************************************
+from pyworkflow.em import EMObject
 from pyworkflow.em.protocol.protocol_tests import ProtOutputTest
 from tests import *
 from pyworkflow.mapper import SqliteMapper
@@ -45,10 +46,37 @@ class TestProtocolOutputs(BaseTest):
         mapper = SqliteMapper(fn, globals())
         prot = ProtOutputTest(mapper=mapper, n=2,
                               workingDir=self.getOutputPath(''))
+
+        # Add and old style output, not in the outputs dictionary
+        prot.output1 = EMObject()
+
+        self.assertFalse(prot._useOutputList.get(),
+                         "useOutputList wrongly initialized")
+
+        outputs = [output for output in prot.iterOutputAttributes()]
+        self.assertTrue(1, len(outputs))
+
+        outputs = [output for output in prot.iterOutputEM()]
+        self.assertTrue(1, len(outputs))
+
+
         prot._stepsExecutor = StepExecutor(hostConfig=None)
         prot.run()
 
         self.assertEqual(prot._steps[0].getStatus(), STATUS_FINISHED)
+
+        # Check there is an output
+        self.assertOutput(prot)
+
+        outputs = [output for output in prot.iterOutputAttributes()]
+
+        self.assertEqual(2, len(outputs),
+                         msg="Integer or OLD output not registered properly.")
+
+
+        self.assertTrue(prot._useOutputList.get(),
+                        "useOutputList not activated")
+
 
     def test_basicObjectInProject(self):
 

--- a/pyworkflow/tests/test_protocol_output.py
+++ b/pyworkflow/tests/test_protocol_output.py
@@ -56,10 +56,6 @@ class TestProtocolOutputs(BaseTest):
         outputs = [output for output in prot.iterOutputAttributes()]
         self.assertTrue(1, len(outputs))
 
-        outputs = [output for output in prot.iterOutputEM()]
-        self.assertTrue(1, len(outputs))
-
-
         prot._stepsExecutor = StepExecutor(hostConfig=None)
         prot.run()
 
@@ -70,7 +66,9 @@ class TestProtocolOutputs(BaseTest):
 
         outputs = [output for output in prot.iterOutputAttributes()]
 
-        self.assertEqual(2, len(outputs),
+        # We are intentionally ignoring a protocol with output (EMObject)
+        # That is continued, We do not find a real case now.
+        self.assertEqual(1, len(outputs),
                          msg="Integer or OLD output not registered properly.")
 
 


### PR DESCRIPTION
Populate the outputList and store it.
iterOutputAttributes allows None as class to return all.
use iterOutputAttributes without EMObject and replace iterOutputsEM by
iterOutputAttributes

@delarosatrevin this is how I understood we should do this after our conversation.
I've unified calls to outputs iteration to a single one (iterOutputAttributes), but left iterOutputEM. Scipion is not using it, except in a test, but I guess plugins might be using them.