### PR TITLE
Jmrt minor changes

### DIFF
--- a/pyworkflow/em/convert/image_handler.py
+++ b/pyworkflow/em/convert/image_handler.py
@@ -384,19 +384,31 @@ class ImageHandler(object):
                                '-i %s -o %s --type gaussian %f %f'
                                % (inputFile, outputFile, std, avg))
 
-    def truncateMask(self, inputFile, outputFile):
-        """ Forces the values of a mask to be between 0 and 1
+    def truncateMask(self, inputFile, outputFile, newDim=None):
+        """ Forces the values of a mask to be between 0 and 1.
+        Additionally, the output mask can be scaled to a new dimension.
+
         Params:
             inputFile: the filename of the input either image or volume
             outputFile: the filename of the output either image or volume
+            newDim: scale the output Mask to a new dimension if not None
         """
+        if inputFile.endswith('.mrc'):
+            inputFile += ':mrc'
+
+        ioStr = '-i %s -o %s' % (inputFile, outputFile)
+
+        if newDim:
+            self.__runXmippProgram('xmipp_image_resize',
+                                   '%s --dim %d' % (ioStr, newDim))
+            ioStr = '-i %s' % outputFile
         self.__runXmippProgram('xmipp_transform_threshold',
-                               '-i %s -o %s --select below 0 --substitute '
-                               'value 0' % (inputFile, outputFile))
-        
+                               '%s --select below 0 --substitute '
+                               'value 0' % ioStr)
+
         self.__runXmippProgram('xmipp_transform_threshold',
                                '-i %s --select above 1 --substitute '
-                               'value 1' % (outputFile))
+                               'value 1' % outputFile)
     
     def isImageFile(self, imgFn):
         """ Check if imgFn has an image extension. The function

--- a/pyworkflow/tests/em/data/test_data.py
+++ b/pyworkflow/tests/em/data/test_data.py
@@ -252,6 +252,21 @@ class TestImageHandler(unittest.TestCase):
         else:
             pwutils.cleanPath(outFn)
 
+    def test_truncateMask(self):
+        ih = ImageHandler()
+
+        maskFn = self.dataset.getFile('masks/mask.vol')
+        outFn = join('/tmp', 'mask.vol')
+
+        ih.truncateMask(maskFn, outFn, newDim=128)
+        EXPECTED_SIZE = (128, 128, 128, 1)
+
+        self.assertTrue(os.path.exists(outFn))
+        self.assertTrue(pwutils.getFileSize(outFn) > 0)
+        self.assertEqual(ih.getDimensions(outFn), EXPECTED_SIZE)
+
+        pwutils.cleanPath(outFn)
+
 
 class TestSetOfMicrographs(BaseTest):
 

--- a/scipion
+++ b/scipion
@@ -173,7 +173,8 @@ try:
     config.read([SCIPION_CONFIG, SCIPION_LOCAL_CONFIG])
 
     def getPaths(section):
-        return dict([(key, join(SCIPION_HOME, os.path.expanduser(path)))
+        return dict([(key, join(SCIPION_HOME,
+                                os.path.expanduser(os.path.expandvars(path))))
                      for key, path in config.items(section)])  # works in 2.4
 
     def getValues(section):


### PR DESCRIPTION
Two main small changes here:

* Allow variables (e.g $USER) in the scipion.conf files: this is very useful when the projects should not be located by default in home and with this change, we can set this automatically without user need to create links or move data.
* Fixed bug in ImageHandler.truncateMask when volumes came from Relion (.mrc without 2014 MRC flags). Additional, a new dimension can be passed to the new mask, this is needed for a protocol in relion to adjust the mask size at the same time as truncating it. A test was added for this case.