### PR TITLE
Including postprocess in 3D section of protocol.conf

### DIFF
--- a/pyworkflow/templates/protocols.template
+++ b/pyworkflow/templates/protocols.template
@@ -48,6 +48,7 @@ Protocols SPA = [
 		{"tag": "protocol_group", "text": "Refine", "openItem": "False", "children": [
 			{"tag": "section", "text": "more", "openItem": "False", "children": []}
 		]},
+		{"tag": "protocol_group", "text": "Postprocess", "openItem": "False", "children": []},
 		{"tag": "protocol_group", "text": "Analysis", "openItem": "False", "children": [
 			{"tag": "section", "text": "Heterogeneity", "openItem": "False", "children": []},
 			{"tag": "section", "text": "Validation", "openItem": "False", "children": []},


### PR DESCRIPTION
Xmipp (localSharpening) and LocScale already have this section and it make sense to be in the tree after refine instead of at the end if not defined here.

Also I propose to include RelionPostProcess protocol in https://github.com/scipion-em/scipion-em-relion/pull/52 PR.

It will looks like:
![image](https://user-images.githubusercontent.com/30288932/56797636-6cc59200-6815-11e9-92a9-9848f7c7e37e.png)
