### PR TITLE
Using binding to PSD estimation

### DIFF
--- a/pyworkflow/em/protocol/protocol_align_movies.py
+++ b/pyworkflow/em/protocol/protocol_align_movies.py
@@ -41,7 +41,6 @@ from pyworkflow.em.data import (MovieAlignment, SetOfMovies, SetOfMicrographs,
 from pyworkflow.em.protocol import ProtProcessMovies
 from pyworkflow.gui.plotter import Plotter
 
-
 class ProtAlignMovies(ProtProcessMovies):
     """
     Base class for movie alignment protocols such as:
@@ -552,13 +551,41 @@ class ProtAlignMovies(ProtProcessMovies):
         self.__runXmippProgram('xmipp_movie_alignment_correlation', args)
 
     def computePSD(self, inputMic, oroot, dim=400, overlap=0.7):
-        args = '--micrograph "%s" --oroot %s ' % (inputMic, oroot)
-        args += '--dont_estimate_ctf --pieceDim %d --overlap %f' % (dim, overlap)
+        import warnings
+        warnings.warn("Use psd = image.computePSD(overlap=0.4, xdim=384, ydim=384, fftthreads=1) instead",
+                      DeprecationWarning)
+        ih = ImageHandler()
+        psdImg1 = ih.read(inputMic)
+        res = psdImg1.computePSD(overlap, dim, dim)
+        res.write(oroot+".psd")
 
-        self.__runXmippProgram('xmipp_ctf_estimate_from_micrograph', args)
+    def composePSDImages(self, psdImg1, psdImg2, outputFn,
+                   outputFnUncorrected=None, outputFnCorrected=None):
+        """ Compose a single PSD image:
+         left part from psd1 (uncorrected PSD),
+         right-part from psd2 (corrected PSD)
+        """
+        data1 = psdImg1.getData() # get the data now, as conversion would change them
+        if outputFnUncorrected is not None:
+            psdImg1.convertPSD()
+            psdImg1.write(outputFnUncorrected)
+
+        data2 = psdImg2.getData() # get the data now, as conversion would change them
+        if outputFnCorrected is not None:
+            psdImg2.convertPSD()
+            psdImg2.write(outputFnCorrected)
+
+        # Compute middle index
+        x, _, _, _ = psdImg1.getDimensions()
+        m = int(round(x / 2.))
+        data1[:, :m] = data2[:, :m]
+        psdImg1.setData(data1)
+        psdImg1.write(outputFn)
 
     def composePSD(self, psd1, psd2, outputFn,
                    outputFnUncorrected=None, outputFnCorrected=None):
+        import warnings
+        warnings.warn("Use composePSDImages() instead", DeprecationWarning)
         """ Compose a single PSD image:
          left part from psd1 (uncorrected PSD),
          right-part from psd2 (corrected PSD)
@@ -585,8 +612,19 @@ class ProtAlignMovies(ProtProcessMovies):
         psdImg1.setData(data1)
         psdImg1.write(outputFn)
 
+    def computePSDImages(self, movie, fnUncorrected, fnCorrected,
+                    outputFnUncorrected=None, outputFnCorrected=None):
+        self.composePSDImages(
+            ImageHandler().read(fnUncorrected).computePSD(),
+            ImageHandler().read(fnCorrected).computePSD(),
+            self._getPsdCorr(movie),
+            outputFnUncorrected,
+            outputFnCorrected)
+
     def computePSDs(self, movie, fnUncorrected, fnCorrected,
                     outputFnUncorrected=None, outputFnCorrected=None):
+        import warnings
+        warnings.warn("Use computePSDImages() instead", DeprecationWarning)
         movieFolder = self._getOutputMovieFolder(movie)
         uncorrectedPSD = os.path.join(movieFolder, "uncorrected")
         correctedPSD = os.path.join(movieFolder, "corrected")

--- a/pyworkflow/em/protocol/protocol_align_movies.py
+++ b/pyworkflow/em/protocol/protocol_align_movies.py
@@ -591,26 +591,7 @@ class ProtAlignMovies(ProtProcessMovies):
          right-part from psd2 (corrected PSD)
         """
         ih = ImageHandler()
-        psdImg1 = ih.read(psd1)
-        data1 = psdImg1.getData()
-
-        if outputFnUncorrected is not None:
-            psdImg1.convertPSD()
-            psdImg1.write(outputFnUncorrected)
-
-        psdImg2 = ih.read(psd2)
-        data2 = psdImg2.getData()
-
-        if outputFnCorrected is not None:
-            psdImg2.convertPSD()
-            psdImg2.write(outputFnCorrected)
-
-        # Compute middle index
-        x, _, _, _ = psdImg1.getDimensions()
-        m = int(round(x / 2.))
-        data1[:, :m] = data2[:, :m]
-        psdImg1.setData(data1)
-        psdImg1.write(outputFn)
+        composePSDImages(self, ih.read(psd1), ih.read(psd2), outputFn, outputFnUncorrected, outputFnCorrected)
 
     def computePSDImages(self, movie, fnUncorrected, fnCorrected,
                     outputFnUncorrected=None, outputFnCorrected=None):
@@ -625,15 +606,7 @@ class ProtAlignMovies(ProtProcessMovies):
                     outputFnUncorrected=None, outputFnCorrected=None):
         import warnings
         warnings.warn("Use computePSDImages() instead", DeprecationWarning)
-        movieFolder = self._getOutputMovieFolder(movie)
-        uncorrectedPSD = os.path.join(movieFolder, "uncorrected")
-        correctedPSD = os.path.join(movieFolder, "corrected")
-        self.computePSD(fnUncorrected, uncorrectedPSD)
-        self.computePSD(fnCorrected, correctedPSD)
-        self.composePSD(uncorrectedPSD + ".psd",
-                        correctedPSD + ".psd",
-                        self._getPsdCorr(movie),
-                        outputFnUncorrected, outputFnCorrected)
+        computePSDImages(self, movie, fnUncorrected, fnCorrected, outputFnUncorrected, outputFnCorrected)
 
     def computeThumbnail(self, inputFn, scaleFactor=6, outputFn=None):
         """ Generates a thumbnail of the input file"""


### PR DESCRIPTION
partly addressing https://github.com/I2PC/xmipp/issues/132
deprecating:
computePSD()
composePSD()
computePSDs()

and adding new alternatives, which do not require repeated data store/load