### PR TITLE
add  progressbar capability to Scipion

### DIFF
--- a/pyworkflow/tests/test_utils.py
+++ b/pyworkflow/tests/test_utils.py
@@ -4,17 +4,18 @@
 Created on Mar 25, 2014
 
 @author: airen
+@author: roberto.marabini
 '''
-import pyworkflow as pw
+
+from __future__ import print_function
 
 from subprocess import Popen
 import pyworkflow.utils as pwutils
 from pyworkflow.utils.process import killWithChilds
 from pyworkflow.tests import *
 from pyworkflow.utils import utils, prettyDict
+from pyworkflow.utils import ProgressBar
 
-
-    
 class TestBibtex(BaseTest):
     """ Some minor tests to the bibtexparser library. """
 
@@ -101,6 +102,54 @@ class TestGetListFromRangeString(BaseTest):
             # Check that also works properly with spaces as delimiters
             s2 = s.replace(',', ' ')
             self.assertEqual(o, pwutils.getListFromRangeString(s2))
+
+class TessProgressBar(unittest.TestCase):
+
+    def caller(self, total, step, fmt, resultGold):
+        ti = time.time()
+        progressBar = ProgressBar(total=total, fmt=fmt, objectId=33)
+
+        result=''
+        for i in xrange(total):
+            if i%step==0:
+                result += progressBar(); sys.stdout.flush()
+                progressBar.current += step
+        result += progressBar.done(); sys.stdout.flush()
+        self.assertEqual(resultGold, result)
+        tf = time.time()
+        print ("%d iterations in %f sec"%(total, tf - ti))
+
+
+    def test_dot(self):
+        total = 1000000
+        step = 10000
+        ratio = int(total/step)
+        resultGold = '.' * (ratio+1)
+        self.caller(total=total, step=step,
+                    fmt=ProgressBar.DOT, resultGold=resultGold)
+
+
+    def test_default(self):
+        total = 3
+        step = 1
+        resultGold = '\rProgress: [                                        ]   0%\rProgress: [=============                           ]  33%\rProgress: [==========================              ]  66%\rProgress: [========================================] 100%'
+        self.caller(total=total, step=step,
+                    fmt=ProgressBar.DEFAULT, resultGold=resultGold)
+
+    def test_full(self):
+        total = 3
+        step = 1
+        resultGold = '\r[                                        ] 0/3 (  0%) 3 to go\r[=============                           ] 1/3 ( 33%) 2 to go\r[==========================              ] 2/3 ( 66%) 1 to go\r[========================================] 3/3 (100%) 0 to go'
+        self.caller(total=total, step=step,
+                    fmt=ProgressBar.FULL, resultGold=resultGold)
+
+    def test_objectid(self):
+        total = 3
+        step = 1
+        ratio = int(total/step)
+        resultGold = '\r[                                        ] 0/3 (  0%) (objectId=33)\r[=============                           ] 1/3 ( 33%) (objectId=33)\r[==========================              ] 2/3 ( 66%) (objectId=33)\r[========================================] 3/3 (100%) (objectId=33)'
+        self.caller(total=total, step=step,
+                    fmt=ProgressBar.OBJID, resultGold=resultGold)
 
 
 if __name__ == '__main__':

--- a/pyworkflow/utils/__init__.py
+++ b/pyworkflow/utils/__init__.py
@@ -34,3 +34,4 @@ from which import *
 from graph import *
 from reflection import *
 from log import *
+from progressbar import ProgressBar

--- a/pyworkflow/utils/progressbar.py
+++ b/pyworkflow/utils/progressbar.py
@@ -30,7 +30,7 @@ class ProgressBar(object):
 
     def __init__(self, total, width=40, fmt=DEFAULT, symbol='=',
                  output=sys.stderr, objectId=None):
-        # total = mamimum number of character to be written per line. Usually the current terminal width
+        # total = maximum number of character to be written per line. Usually the current terminal width
         # width = progress bar width (without the percentange and number of iterations loop)
         # predefined format string, so far DEFAULT, FULL, OBJID and DOT are defined.
         # symbol: progress bar is made with this symbol
@@ -42,6 +42,7 @@ class ProgressBar(object):
         self.symbol = symbol
         self.output = output
         self.objectId = objectId
+        
         if fmt == self.DOT:
             self.directPrint = True
             self.fnt = self.DOT

--- a/pyworkflow/utils/progressbar.py
+++ b/pyworkflow/utils/progressbar.py
@@ -32,7 +32,7 @@ class ProgressBar(object):
                  output=sys.stderr, objectId=None):
         # total = mamimum number of character to be written per line. Usually the current terminal width
         # width = progress bar width (without the percentange and number of iterations loop)
-        # predefined format string, so far DEFAULT, FULL, objId are defined.
+        # predefined format string, so far DEFAULT, FULL, OBJID and DOT are defined.
         # symbol: progress bar is made with this symbol
 
         assert len(symbol) == 1

--- a/pyworkflow/utils/progressbar.py
+++ b/pyworkflow/utils/progressbar.py
@@ -48,6 +48,9 @@ class ProgressBar(object):
     """
     DEFAULT = 'Progress: %(bar)s %(percent)3d%%'
     FULL = '%(bar)s %(current)d/%(total)d (%(percent)3d%%) %(remaining)d to go'
+    # scipion uses variable fonts so the bar size changes
+    # since the space widt is different from the = width
+    NOBAR = '%(current)d/%(total)d (%(percent)3d%%) %(remaining)d to go'
     OBJID = '%(bar)s %(current)d/%(total)d (%(percent)3d%%) (objectId=%(objectId)d)'
     DOT = '.'
 
@@ -126,8 +129,11 @@ class ProgressBar(object):
         self._output.write(self.__getStr())
         self._output.flush()
 
-    def finish(self):
+    def finish(self, printNewLine=True):
         """ Finalize the progress and
         print last update with 100% complete message """
         if self._current < self._total:
             self.update(self._total)
+        # print a new line
+        if printNewLine:
+            self._output.write("\n")

--- a/pyworkflow/utils/progressbar.py
+++ b/pyworkflow/utils/progressbar.py
@@ -1,0 +1,80 @@
+from __future__ import print_function
+import sys
+import re
+
+###############################################
+# progressbar
+# EXAMPLE:
+#
+# from time import sleep
+
+# progress = ProgressBar(1000, fmt=ProgressBar.FULL)
+# for x in xrange(progress.total):
+#    progress.current += 1
+#    print progress()
+#    sleep(0.1)
+# print progress.done()
+
+
+class ProgressBar(object):
+    """Text progress bar class for Python.
+
+    A text progress bar is typically used to display the progress of a long
+    running operation, providing a visual cue that processing is underway.
+    """
+
+    DEFAULT = 'Progress: %(bar)s %(percent)3d%%'
+    FULL = '%(bar)s %(current)d/%(total)d (%(percent)3d%%) %(remaining)d to go'
+    OBJID = '%(bar)s %(current)d/%(total)d (%(percent)3d%%) (objectId=%(objectId)d)'
+    DOT = '.'
+
+    def __init__(self, total, width=40, fmt=DEFAULT, symbol='=',
+                 output=sys.stderr, objectId=None):
+        # total = mamimum number of character to be written per line. Usually the current terminal width
+        # width = progress bar width (without the percentange and number of iterations loop)
+        # predefined format string, so far DEFAULT, FULL, objId are defined.
+        # symbol: progress bar is made with this symbol
+
+        assert len(symbol) == 1
+
+        self.total = total
+        self.width = width
+        self.symbol = symbol
+        self.output = output
+        self.objectId = objectId
+        if fmt == self.DOT:
+            self.directPrint = True
+            self.fnt = self.DOT
+        else:
+            self.directPrint = False
+            # This line computes the number of digits
+            # in total and rewrites the fmt string
+            # so if total = 100, %d is converted to %3d
+            self.fmt = re.sub(r'(?P<name>%\(.+?\))d',
+                r'\g<name>%dd' % len(str(total)), fmt)
+        self.current = 0
+
+    def __call__(self):
+        # print just a dot
+        if self.directPrint:
+            return self.fnt
+        else:  # print percentages
+            percent = self.current / float(self.total)
+            size = int(self.width * percent)
+            remaining = self.total - self.current
+            bar = '[' + self.symbol * size + ' ' * (self.width - size) + ']'
+
+            args = {
+                'total': self.total,
+                'bar': bar,
+                'current': self.current,
+                'percent': percent * 100,
+                'remaining': remaining,
+                'objectId': self.objectId
+            }
+            return('\r' + self.fmt % args)
+
+    def done(self):
+        # print last update with 100% complete message
+        self.current = self.total
+        return(self())


### PR DESCRIPTION
Prints a progressbar. There are four predefined formats: dot, deafult, full, objedid

Esamples
```
dot
           .............................................
full
           [======                                  ] 1/3 (  33%) 2 to go
default
           Progress: [                                        ]   0%
objectid
         [                                        ] 0/3 (  0%) (objectId=33)          

```
Tests; 

./scipion test pyworkflow.tests.test_utils.TessProgressBar.test_dot
./scipion test pyworkflow.tests.test_utils.TessProgressBar.test_default
./scipion test pyworkflow.tests.test_utils.TessProgressBar.test_full
./scipion test pyworkflow.tests.test_utils.TessProgressBar.test_objectid


Example of use:
```

 from time import sleep
 from pyworkflow.utils import Progressbar

 progress = ProgressBar(1000, fmt=ProgressBar.FULL)
 for x in xrange(progress.total):
    progress.current += 1
    print progress()
    sleep(0.1)
 print progress.done()
```