### PR TITLE
Catching the error when a warning mail sending fails

### DIFF
--- a/pyworkflow/em/protocol/monitors/protocol_monitor.py
+++ b/pyworkflow/em/protocol/monitors/protocol_monitor.py
@@ -199,11 +199,19 @@ class EmailNotifier():
         msg['From'] = self._emailFrom
         msg['To'] = self._emailTo
 
-        # Send the message via our own SMTP server, but don't include the
-        # envelope header.
-        s = smtplib.SMTP(self._smtpServer)
-        s.sendmail(self._emailFrom, self._emailTo, msg.as_string())
-        s.quit()
+        try:
+            # Send the message via our own SMTP server, but don't include the
+            # envelope header.
+            s = smtplib.SMTP(self._smtpServer)
+            s.sendmail(self._emailFrom, self._emailTo, msg.as_string())
+            s.quit()
+        except:
+            import traceback
+            print("Some error happened while trying to send email warning.")
+            print(" > Error:")
+            traceback.print_exc()
+            print(" > Message:")
+            print(msg.as_string())
 
 
 class PrintNotifier():

--- a/pyworkflow/em/protocol/monitors/protocol_monitor.py
+++ b/pyworkflow/em/protocol/monitors/protocol_monitor.py
@@ -206,10 +206,10 @@ class EmailNotifier():
             s.sendmail(self._emailFrom, self._emailTo, msg.as_string())
             s.quit()
         except:
-            import traceback
+            from traceback import print_exc
             print("Some error happened while trying to send email warning.")
             print(" > Error:")
-            traceback.print_exc()
+            print_exc()
             print(" > Message:")
             print(msg.as_string())
 


### PR DESCRIPTION
When a user sets a mail to warn if some acquisition value goes out of range and the mail sending fails, the monitor is freezed due to the error, so far.

With this update, we just print the error and the warning while the monitor continues working. This make sense to be able to keep populating the HTML report.