### PR TITLE
Join set do not loose ids of first set

### DIFF
--- a/pyworkflow/em/constants.py
+++ b/pyworkflow/em/constants.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 # **************************************************************************
 # *
 # * Authors:     J.M. De la Rosa Trevin (jmdelarosa@cnb.csic.es)

--- a/pyworkflow/em/protocol/protocol_sets.py
+++ b/pyworkflow/em/protocol/protocol_sets.py
@@ -142,8 +142,7 @@ class ProtUnionSet(ProtSets):
 
         # Renumber from the beginning if either the renumber option is selected
         # or we find duplicated ids in the sets
-        cleanIds = ((not self.ignoreDuplicates.get() and self.duplicatedIds())
-                        or self.renumber.get())
+        cleanIds = not self.ignoreDuplicates.get() and self.duplicatedIds()
 
         #TODO ROB remove ignoreExtraAttributes condition
         #or implement it. But this will be for Scipion 1.2
@@ -158,7 +157,9 @@ class ProtUnionSet(ProtSets):
                     copyAttrs.append(attr)
 
         idsList = []
+        setNum = 0
         for itemSet in self.inputSets:
+            setNum += 1
             for obj in itemSet.get():
                 objId = obj.getObjId()
                 if self.ignoreDuplicates.get():
@@ -171,13 +172,15 @@ class ProtUnionSet(ProtSets):
                     newObj.copyAttributes(obj, *copyAttrs)
 
                     self.cleanExtraAttributes(newObj, commonAttrs)
-                    if not cleanIds:
+                    if not cleanIds or setNum == 1:
                         newObj.setObjId(objId)
                 else:
                     newObj = obj
 
-                if cleanIds:
+                if (cleanIds and setNum > 1) or self.renumber.get():
                     newObj.cleanObjId()
+                print ("FINAL ID: %s" % newObj.getObjId())
+                print ("OBJ ID: %s" % objId)
                 outputSet.append(newObj)
 
         self._defineOutputs(outputSet=outputSet)

--- a/pyworkflow/em/protocol/protocol_sets.py
+++ b/pyworkflow/em/protocol/protocol_sets.py
@@ -179,8 +179,7 @@ class ProtUnionSet(ProtSets):
 
                 if (cleanIds and setNum > 1) or self.renumber.get():
                     newObj.cleanObjId()
-                print ("FINAL ID: %s" % newObj.getObjId())
-                print ("OBJ ID: %s" % objId)
+
                 outputSet.append(newObj)
 
         self._defineOutputs(outputSet=outputSet)

--- a/pyworkflow/em/protocol/protocol_sets.py
+++ b/pyworkflow/em/protocol/protocol_sets.py
@@ -186,6 +186,12 @@ class ProtUnionSet(ProtSets):
         for itemSet in self.inputSets:
             self._defineSourceRelation(itemSet, outputSet)
 
+    # Overwrite SetOfCoordinates creation
+    def _createSetOfCoordinates(self, suffix=''):
+        coordSet = self.inputSets[0].get()
+        micSet = coordSet.getMicrographs()
+        return ProtSets._createSetOfCoordinates(self, micSet, suffix)
+
     def cleanExtraAttributes(self, obj, verifyAttrs, prefix=""):
 
         for attr, value in obj.getAttributesToStore():

--- a/pyworkflow/gui/project/viewprojects.py
+++ b/pyworkflow/gui/project/viewprojects.py
@@ -98,6 +98,7 @@ class ProjectsView(tk.Frame):
         for i, p in enumerate(self.manager.listProjects()):
             try:
                 project = self.manager.loadProject(p.getName(), chdir=False, loadAllConfig=False)
+                project.closeMapper()
                 # Add creation time to project info
                 p.cTime = project.getCreationTime()
                 # Add if it's a link

--- a/pyworkflow/object.py
+++ b/pyworkflow/object.py
@@ -1186,7 +1186,7 @@ class Set(OrderedObject):
             self._idCount += 1
             item.setObjId(self._idCount)
         else:
-            self._idCount = max(self._idCount, item.getObjId()) + 1
+            self._idCount = max(self._idCount, item.getObjId())
         self._insertItem(item)
         self._size.increment()
 

--- a/pyworkflow/tests/em/protocols/test_protocols_sets.py
+++ b/pyworkflow/tests/em/protocols/test_protocols_sets.py
@@ -417,8 +417,9 @@ class TestSets(BaseTest):
         imgSet2 = SetOfParticles(filename=inFileNameMetadata2)
 
         inFileNameData = self.proj.getTmpPath('particles.stk')
-        img1 = Particle()
-        img2 = Particle()
+        # Start ids 4
+        img1 = Particle(objId=4)
+        img2 = Particle(objId=4)
         attrb1 = [11, 12, 13, 14]
         attrb2 = [21, 22, 23, 24]
         attrb3 = [31, 32]
@@ -431,7 +432,8 @@ class TestSets(BaseTest):
         img2.setCTF(ctf2)
 
         for i in range(1, 3):
-            img1.cleanObjId()
+            # Increment Id
+            img1.setObjId(img1.getObjId()+1)
             img1.setLocation(i, inFileNameData)
             img1.setMicId(i % 3)
             img1.setClassId(i % 5)
@@ -443,7 +445,8 @@ class TestSets(BaseTest):
             counter += 1
 
         for i in range(1, 3):
-            img2.cleanObjId()
+            # Increment Id
+            img2.setObjId(img2.getObjId()+1)
             img2.setLocation(i, inFileNameData)
             img2.setClassId(i % 5)
             img2.setMicId(i % 3)
@@ -498,6 +501,10 @@ class TestSets(BaseTest):
             self.assertIsNotNone(ctf, "Image should have CTF after join")
             self.assertFalse(hasattr(ctf, '_myOwnQuality'),
                              "CTF should not have non common attributes")
+
+            # Assert ids
+            self.assertEqual(counter+5, img.getObjId(),
+                             "Object id's not kept.")
             counter += 1
 
     def testOrderBy(self):


### PR DESCRIPTION
This PR has 3 small changes:
1.- The join sets was losing the ids as soon as there were conflicts. Now, if allowed, it will keep the id of the first set. This will allow the usage of other protocols that us the Id for matching items, at least for the first set that is being merged.
2.- Fixes a "bug"  in the _idCount of the sets
3.- Closes the bd after loading the project info in the project list window.