### PR TITLE
Minor changes introduced for Tomo

### DIFF
--- a/pyworkflow/em/convert/atom_struct.py
+++ b/pyworkflow/em/convert/atom_struct.py
@@ -671,7 +671,7 @@ def cifToPdb(fnCif,fnPdb):
 def pdbToCif(fnPdb, fnCif):
     h = AtomicStructHandler()
     h.read(fnPdb)
-    h.writeAsPdb(fnCif)
+    h.writeAsCif(fnCif)
 
 def toPdb(inFileName, outPDBFile):
     if inFileName.endswith(".pdb") or inFileName.endswith(".ent"):

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -1752,12 +1752,15 @@ class SetOfClasses(EMSet):
     def getSamplingRate(self):
         return self.getImages().getSamplingRate()
 
-    def appendFromClasses(self, classesSet):
+    def appendFromClasses(self, classesSet, filterClassFunc=None):
         """ Iterate over the classes and the elements inside each
         class and append classes and items that are enabled.
         """
+        if filterClassFunc is None:
+            filterClassFunc = lambda cls: True
+
         for cls in classesSet:
-            if cls.isEnabled():
+            if cls.isEnabled() and filterClassFunc(cls):
                 newCls = self.ITEM_TYPE()
                 newCls.copyInfo(cls)
                 newCls.setObjId(cls.getObjId())

--- a/pyworkflow/em/data.py
+++ b/pyworkflow/em/data.py
@@ -1260,6 +1260,9 @@ class SetOfVolumes(SetOfImages):
     ITEM_TYPE = Volume
     REP_TYPE = Volume
 
+    # Hint to GUI components to expose internal items for direct selection
+    EXPOSE_ITEMS = True
+
     def __init__(self, **kwargs):
         SetOfImages.__init__(self, **kwargs)
 
@@ -1322,6 +1325,8 @@ class SetOfDefocusGroup(EMSet):
 class SetOfAtomStructs(EMSet):
     """ Set containing PDB items. """
     ITEM_TYPE = AtomStruct
+    # Hint to GUI components to expose internal items for direct selection
+    EXPOSE_ITEMS = True
 
 
 class SetOfPDBs(SetOfAtomStructs):

--- a/pyworkflow/gui/form.py
+++ b/pyworkflow/gui/form.py
@@ -444,15 +444,11 @@ class SubclassesTreeProvider(TreeProvider):
                             p._allowsSelection = True
                             objects.append(p)
 
-                        # JMRT: Adding the inner items cause a significant
-                        # performance penalty, anyway, subsets can be selected
-                        # from showj GUI and used as inputs.
-                        # If attr is a set, then we should consider its elements
-                        # JMRT: The inclusion of subitems as possible inputs
-                        # is causing a performance penalty. So for the moment
-                        # we will restrict that to SetOfVolumes only
-                        if isinstance(attr, em.SetOfVolumes) or \
-                                isinstance(attr, em.SetOfAtomStructs):
+                        # JMRT: For all sets, we don't want to include the
+                        # subitems here for performance reasons (e.g SetOfParticles)
+                        # Thus, a Set class can define EXPOSE_ITEMS = True
+                        # to enable the inclusion of its items here
+                        if getattr(attr, 'EXPOSE_ITEMS', False):
                             # If the ITEM type match any of the desired classes
                             # we will add some elements from the set
                             if (attr.ITEM_TYPE is not None and


### PR DESCRIPTION
### Changes:
* Introduced EXPOSE_ITEMS as static property in Set classes. It will be used in the GUI to allow (or not) to choose the subitems in the browser tree. Due to performance issues, it was (hardcoded) allowed only for SetOfVolumes and atomic structures. 
* Optional extra argument filterClassFunc to avoid some classes when operating with sets. 