### PR TITLE
Fixed import from pdb

### DIFF
--- a/pyworkflow/em/convert/atom_struct.py
+++ b/pyworkflow/em/convert/atom_struct.py
@@ -210,7 +210,7 @@ class AtomicStructHandler:
         """
         if dir is None:
             dir = os.getcwd()
-        pdbl = PDBList()
+        pdbl = PDBList(pdb=dir)
         fileName = pdbl.retrieve_pdb_file(pdbID, pdir=dir, file_format=type)
         self.read(fileName)
         self.write(fileName)  # many  atom structs need to be fixed


### PR DESCRIPTION
PDBList __init__ has the default value  pdb=os.getcwd() unfortunately initializing parameters with something that is mutable is bad practice.  The reason for this is that the def statement only gets executed once, which is when the function is defined. Thus the initializer value only gets created once. For a reference type (as opposed to an immutable type which cannot change) like a function or a dictionary, this ends up as a visible and surprising pitfall, whereas for value types, it goes unnoticed.

In summary, we modify the call to PDBlist so it passes explicitly the value of the pdb argument.

Note, I do not modify PDBList.__init_definition  because is a biopython function, that is, belongs to an external module.