### PR TITLE
Ds fixing movie shift plot

### DIFF
--- a/pyworkflow/em/protocol/protocol_align_movies.py
+++ b/pyworkflow/em/protocol/protocol_align_movies.py
@@ -689,26 +689,13 @@ def createAlignmentPlot(meanX, meanY):
 
     ax = figure.add_subplot(111)
     ax.grid()
-    ax.axis('equal')
+    ax.axis('auto')
     ax.set_title('Cartesian representation')
     ax.set_xlabel('Drift x (pixels)')
     ax.set_ylabel('Drift y (pixels)')
-    
-    # Max range of the plot of the two coordinates
-    plotRange = max(max(meanX)-min(meanX), max(meanY)-min(meanY))
-    i = 1 
-    skipLabels = ceil(len(meanX) / 10.0)
-    for x, y in izip(meanX, meanY):
-        if i % skipLabels == 0:
-            ax.text(x-0.02*plotRange, y+0.02*plotRange, str(i))
-        i += 1
 
     ax.plot(meanX, meanY, color='b')
     ax.plot(meanX, meanY, 'yo')
-
-    # setting the plot windows to properly see the data
-    ax.axis([min(meanX)-0.1*plotRange, max(meanX)+0.1*plotRange, 
-             min(meanY)-0.1*plotRange, max(meanY)+0.1*plotRange])
     
     plotter.tightLayout()
 


### PR DESCRIPTION
This PR lifts restriction we posed on graph generation, mainly equal axis scale.
As a result, it should automatically scale the axis, and making plots with dominant direction more easy to read, as in example bellow (left before, right after [note: it plots two different data sets, so the ranges differ]):
![image](https://user-images.githubusercontent.com/28389367/78554735-f7778500-780b-11ea-9690-b5c9a7f85a09.png)
